### PR TITLE
Fix unspecified version in fabric.mod.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,5 +29,5 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: modern-industrialization
+        name: modern-industrialization ${{ steps.var.outputs.commit_hash }}
         path: build/libs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - id: var
+      name: Setup variables
+      run: echo ::set-output name=commit_hash::${GITHUB_SHA:0:7}
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
@@ -21,6 +24,8 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
     - name: Build with Gradle
       run: ./gradlew build
+      env:
+        MI_VERSION: git-${{ steps.var.outputs.commit_hash }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,5 +28,5 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: modern-industrialization
+          name: modern-industrialization ${{ steps.var.outputs.commit_hash }}
           path: build/libs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,5 +28,5 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: modern-industrialization ${{ steps.var.outputs.commit_hash }}
+          name: modern-industrialization ${{ github.event.release.tag_name }}
           path: build/libs

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,10 @@ plugins {
     id 'com.matthewprenger.cursegradle' version '1.4.0'
 }
 
+version = System.getenv("MI_VERSION")
+        ? System.getenv("MI_VERSION")
+        : "local"
+
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
@@ -293,9 +297,6 @@ final class JsonOrderStep {
     }
 }
 
-if (System.getenv("MI_VERSION")) {
-    version = System.getenv("MI_VERSION")
-}
 def releaseChannel = "beta"
 def changelog = "Please visit our github repository for a changelog: https://github.com/AztechMC/Modern-Industrialization/releases."
 if (version.toLowerCase().contains("alpha")) {


### PR DESCRIPTION
Setting the version after `processResources` makes it uses the old version value, which is `unspecified`, fixed it by moving the assignment to the top.
![487xrSZ](https://user-images.githubusercontent.com/21150434/119249591-de729480-bbc3-11eb-8182-818c5f6650a7.png)

I also made the commit hash as the version for master build actions. I just think it's a little nicer.
The version will defaults to `local` if built it locally without the env var.
![2021-05-23 12_46_15-libs](https://user-images.githubusercontent.com/21150434/119249707-e7b03100-bbc4-11eb-9338-3c9567798560.png)
