### PR TITLE
Add native support for macerator for silver ore

### DIFF
--- a/src/main/java/aztech/modern_industrialization/compat/RecipeCompat.java
+++ b/src/main/java/aztech/modern_industrialization/compat/RecipeCompat.java
@@ -80,6 +80,7 @@ public class RecipeCompat {
             addMiRecipe("macerator", "#c:sodalite_ores", "techreborn:sodalite_dust", 2);
             addMiRecipe("macerator", "techreborn:yellow_garnet_gem", "techreborn:yellow_garnet_dust", 1);
             addMiRecipe("macerator", "#c:zinc_ingots", "techreborn:zinc_dust", 1);
+            addMiRecipe("macerator", "#c:silver_ores", "techreborn:raw_silver", 2);
 
             for (Material material : MaterialRegistry.getMaterials().values()) {
                 if (material.getParts().containsKey(MIParts.CURVED_PLATE)) {
@@ -116,6 +117,7 @@ public class RecipeCompat {
             ModernIndustrialization.LOGGER.info("Industrial Revolution is detected, loading compatibility recipes for Modern Industrialization!");
 
             addMiRecipe("macerator", "indrev:nikolite_ore", "indrev:nikolite_dust", 7);
+            addMiRecipe("macerator", "#c:silver_ores", "indrev:raw_silver", 2);
 
             // quarry recipe for nikolite
             addRecipe("quarry_nikolite",


### PR DESCRIPTION
Hi!

Small change for runtime recipes which adding support to macerator recipes, like an original, for silver ore

Added separately for "tech reborn" and "industrial revolution".

Do you know, maybe yet another mods which have silver ore and which need add?

Before (not have available recipes for macerator):

![image](https://user-images.githubusercontent.com/6960655/130364174-716e189f-f056-4be4-be9e-b5309634fa13.png)
![image](https://user-images.githubusercontent.com/6960655/130364179-63a06e6d-c3d4-4ba0-8f80-d58b672f8774.png)

After (available recipes for macerator):
![image](https://user-images.githubusercontent.com/6960655/130364183-ded5023c-8d49-4ec4-a78b-f768671192b4.png)
![image](https://user-images.githubusercontent.com/6960655/130364185-fd7c55fd-ab70-4d6b-842b-c9084fe3a57d.png)

---

And what are you think about extracting logic for runtime adding recipes per type/group/machine type in separate libs? For give an opportunity for other mod developers use this libs (and make some standard for registering, deduplicating and using runtime recipes)?