### PR TITLE
Simple fix of issue #138

### DIFF
--- a/src/main/java/aztech/modern_industrialization/misc/version/VersionEvents.java
+++ b/src/main/java/aztech/modern_industrialization/misc/version/VersionEvents.java
@@ -57,7 +57,7 @@ public class VersionEvents {
         }
     }
 
-    private static Version fetchVersion(Boolean isIncludeAlphaVersion) throws Exception {
+    private static Version fetchVersion(boolean isIncludeAlphaVersion) throws Exception {
         String mcVersion = FabricLoader.getInstance().getModContainer("minecraft").get().getMetadata().getVersion().getFriendlyString();
 
         URLConnection connection;


### PR DESCRIPTION
Hello, it's me again :)

Old behavior:
![image](https://user-images.githubusercontent.com/6960655/138422899-4fe9cc71-0540-460e-bf65-01810d968d2a.png)
New behavior - no message to user

Closes #138 