### PR TITLE
Profession Blocks

### DIFF
--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/barrel.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/barrel.json
@@ -12,6 +12,12 @@
       "amount": 2
     }
   ],
+  "fluid_inputs": [
+        {
+            "fluid": "modern_industrialization:creosote",
+            "amount": 100
+        }
+  ],
   "item_outputs": [
     {
       "item": "minecraft:barrel",

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/bell.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/bell.json
@@ -5,11 +5,7 @@
     "item_inputs": [
         {
             "item": "minecraft:stick",
-            "amount": 1
-        },
-        {
-            "item": "minecraft:stone_slab",
-            "amount": 2
+            "amount": 3
         },
         {
             "item": "modern_industrialization:bronze_plate",

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/bell.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/bell.json
@@ -1,0 +1,35 @@
+{
+    "type": "modern_industrialization:assembler",
+    "eu": 8,
+    "duration": 200,
+    "item_inputs": [
+        {
+            "item": "minecraft:stick",
+            "amount": 1
+        },
+        {
+            "item": "minecraft:stone_slab",
+            "amount": 2
+        },
+        {
+            "item": "modern_industrialization:bronze_plate",
+            "amount": 1
+        },
+        {
+            "item": "modern_industrialization:bronze_curved_plate",
+            "amount": 2
+        }
+    ],
+    "fluid_inputs": [
+        {
+            "fluid": "modern_industrialization:creosote",
+            "amount": 100
+        }
+    ],
+    "item_outputs": [
+        {
+            "item": "minecraft:bell",
+            "amount": 2
+        }
+    ]
+}

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/bell.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/bell.json
@@ -12,6 +12,10 @@
             "amount": 1
         },
         {
+            "item": "modern_industrialization:bronze_bolt",
+            "amount": 1
+        },
+        {
             "item": "modern_industrialization:bronze_curved_plate",
             "amount": 4
         }

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/bell.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/bell.json
@@ -17,7 +17,7 @@
         },
         {
             "item": "modern_industrialization:bronze_curved_plate",
-            "amount": 2
+            "amount": 4
         }
     ],
     "fluid_inputs": [

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/bell.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/bell.json
@@ -4,8 +4,8 @@
     "duration": 200,
     "item_inputs": [
         {
-            "item": "minecraft:stick",
-            "amount": 3
+            "item": "modern_industrialization:bronze_ring",
+            "amount": 1
         },
         {
             "item": "modern_industrialization:bronze_plate",
@@ -18,7 +18,7 @@
     ],
     "fluid_inputs": [
         {
-            "fluid": "modern_industrialization:creosote",
+            "fluid": "modern_industrialization:solder",
             "amount": 100
         }
     ],

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/bell.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/bell.json
@@ -18,7 +18,7 @@
     ],
     "fluid_inputs": [
         {
-            "fluid": "modern_industrialization:solder",
+            "fluid": "modern_industrialization:soldering_alloy",
             "amount": 100
         }
     ],

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/bookshelf.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/bookshelf.json
@@ -1,0 +1,28 @@
+{
+    "type": "modern_industrialization:assembler",
+    "eu": 8,
+    "duration": 200,
+    "item_inputs": [
+        {
+            "item": "minecraft:book",
+            "amount": 3
+        },
+        {
+            "tag": "minecraft:planks",
+            "amount": 6
+        }
+    ],
+
+    "fluid_inputs": [
+        {
+            "fluid": "modern_industrialization:creosote",
+            "amount": 100
+        }
+    ],
+    "item_outputs": [
+        {
+            "item": "minecraft:bookshelf",
+            "amount": 2
+        }
+    ]
+}

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/bookshelf.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/bookshelf.json
@@ -12,7 +12,6 @@
             "amount": 6
         }
     ],
-
     "fluid_inputs": [
         {
             "fluid": "modern_industrialization:creosote",

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/brewing_stand.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/brewing_stand.json
@@ -1,0 +1,21 @@
+{
+    "type": "modern_industrialization:assembler",
+    "eu": 8,
+    "duration": 200,
+    "item_inputs": [
+        {
+            "item": "minecraft:blaze_rod",
+            "amount": 1
+        },
+        {
+            "tag": "minecraft:stone_tool_materials",
+            "amount": 3
+        }
+    ],
+    "item_outputs": [
+        {
+            "item": "minecraft:brewing_stand",
+            "amount": 2
+        }
+    ]
+}

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/cartography_table.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/cartography_table.json
@@ -1,0 +1,28 @@
+{
+    "type": "modern_industrialization:assembler",
+    "eu": 8,
+    "duration": 200,
+    "item_inputs": [
+        {
+            "item": "minecraft:paper",
+            "amount": 2
+        },
+        {
+            "tag": "minecraft:planks",
+            "amount": 4
+        }
+    ],
+
+    "fluid_inputs": [
+        {
+            "fluid": "modern_industrialization:creosote",
+            "amount": 100
+        }
+    ],
+    "item_outputs": [
+        {
+            "item": "minecraft:cartography_table",
+            "amount": 2
+        }
+    ]
+}

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/cartography_table.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/cartography_table.json
@@ -12,7 +12,6 @@
             "amount": 4
         }
     ],
-
     "fluid_inputs": [
         {
             "fluid": "modern_industrialization:creosote",

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/composter.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/composter.json
@@ -1,23 +1,27 @@
 {
-    "type": "modern_industrialization:assembler",
-    "eu": 8,
-    "duration": 200,
-    "item_inputs": [
-        {
-            "tag": "minecraft:wooden_slabs",
-            "amount": 7
-        }
-    ],
-    "fluid_inputs": [
-        {
-            "fluid": "modern_industrialization:creosote",
-            "amount": 100
-        }
-    ],
-    "item_outputs": [
-        {
-            "item": "minecraft:composter",
-            "amount": 2
-        }
-    ]
+  "type": "modern_industrialization:assembler",
+  "eu": 8,
+  "duration": 200,
+  "item_inputs": [
+    {
+      "tag": "minecraft:wooden_slabs",
+      "amount": 7
+    },
+    {
+      "item": "minecraft:wheat_seeds",
+      "amount": 1
+    }
+  ],
+  "fluid_inputs": [
+    {
+      "fluid": "modern_industrialization:creosote",
+      "amount": 100
+    }
+  ],
+  "item_outputs": [
+    {
+      "item": "minecraft:composter",
+      "amount": 2
+    }
+  ]
 }

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/composter.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/composter.json
@@ -1,0 +1,24 @@
+{
+    "type": "modern_industrialization:assembler",
+    "eu": 8,
+    "duration": 200,
+    "item_inputs": [
+        {
+            "tag": "minecraft:wooden_slabs",
+            "amount": 7
+        }
+    ],
+
+    "fluid_inputs": [
+        {
+            "fluid": "modern_industrialization:creosote",
+            "amount": 100
+        }
+    ],
+    "item_outputs": [
+        {
+            "item": "minecraft:composter",
+            "amount": 2
+        }
+    ]
+}

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/composter.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/composter.json
@@ -8,7 +8,6 @@
             "amount": 7
         }
     ],
-
     "fluid_inputs": [
         {
             "fluid": "modern_industrialization:creosote",

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/fletching_table.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/fletching_table.json
@@ -1,0 +1,28 @@
+{
+    "type": "modern_industrialization:assembler",
+    "eu": 8,
+    "duration": 200,
+    "item_inputs": [
+        {
+            "item": "minecraft:flint",
+            "amount": 2
+        },
+        {
+            "tag": "minecraft:planks",
+            "amount": 4
+        }
+    ],
+
+    "fluid_inputs": [
+        {
+            "fluid": "modern_industrialization:creosote",
+            "amount": 100
+        }
+    ],
+    "item_outputs": [
+        {
+            "item": "minecraft:fletching_table",
+            "amount": 2
+        }
+    ]
+}

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/fletching_table.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/fletching_table.json
@@ -12,7 +12,6 @@
             "amount": 4
         }
     ],
-
     "fluid_inputs": [
         {
             "fluid": "modern_industrialization:creosote",

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/grindstone.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/grindstone.json
@@ -25,7 +25,7 @@
     "item_outputs": [
         {
             "item": "minecraft:grindstone",
-            "amount": 1
+            "amount": 2
         }
     ]
 }

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/grindstone.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/grindstone.json
@@ -1,0 +1,31 @@
+{
+    "type": "modern_industrialization:assembler",
+    "eu": 8,
+    "duration": 200,
+    "item_inputs": [
+        {
+            "item": "minecraft:stone_slab",
+            "amount": 1
+        },
+        {
+            "item": "minecraft:stick",
+            "amount": 2
+        },
+        {
+            "tag": "minecraft:planks",
+            "amount": 2
+        }
+    ],
+    "fluid_inputs": [
+        {
+            "fluid": "modern_industrialization:creosote",
+            "amount": 100
+        }
+    ],
+    "item_outputs": [
+        {
+            "item": "minecraft:grindstone",
+            "amount": 1
+        }
+    ]
+}

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/lectern.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/lectern.json
@@ -1,0 +1,28 @@
+{
+    "type": "modern_industrialization:assembler",
+    "eu": 8,
+    "duration": 200,
+    "item_inputs": [
+        {
+            "item": "minecraft:bookshelf",
+            "amount": 1
+        },
+        {
+            "tag": "minecraft:planks",
+            "amount": 4
+        }
+    ],
+
+    "fluid_inputs": [
+        {
+            "fluid": "modern_industrialization:creosote",
+            "amount": 100
+        }
+    ],
+    "item_outputs": [
+        {
+            "item": "minecraft:lectern",
+            "amount": 2
+        }
+    ]
+}

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/lectern.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/lectern.json
@@ -8,7 +8,7 @@
             "amount": 1
         },
         {
-            "tag": "minecraft:planks",
+            "tag": "minecraft:wooden_slabs",
             "amount": 4
         }
     ],

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/lectern.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/lectern.json
@@ -12,7 +12,6 @@
             "amount": 4
         }
     ],
-
     "fluid_inputs": [
         {
             "fluid": "modern_industrialization:creosote",

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/loom.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/loom.json
@@ -12,7 +12,6 @@
             "amount": 4
         }
     ],
-
     "fluid_inputs": [
         {
             "fluid": "modern_industrialization:creosote",

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/loom.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/loom.json
@@ -1,0 +1,28 @@
+{
+    "type": "modern_industrialization:assembler",
+    "eu": 8,
+    "duration": 200,
+    "item_inputs": [
+        {
+            "item": "minecraft:string",
+            "amount": 2
+        },
+        {
+            "tag": "minecraft:planks",
+            "amount": 4
+        }
+    ],
+
+    "fluid_inputs": [
+        {
+            "fluid": "modern_industrialization:creosote",
+            "amount": 100
+        }
+    ],
+    "item_outputs": [
+        {
+            "item": "minecraft:loom",
+            "amount": 2
+        }
+    ]
+}

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/smithing_table.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/smithing_table.json
@@ -1,0 +1,28 @@
+{
+    "type": "modern_industrialization:assembler",
+    "eu": 8,
+    "duration": 200,
+    "item_inputs": [
+        {
+            "item": "modern_industrialization:steel_plate",
+            "amount": 2
+        },
+        {
+            "tag": "minecraft:planks",
+            "amount": 4
+        }
+    ],
+
+    "fluid_inputs": [
+        {
+            "fluid": "modern_industrialization:creosote",
+            "amount": 100
+        }
+    ],
+    "item_outputs": [
+        {
+            "item": "minecraft:smithing_table",
+            "amount": 2
+        }
+    ]
+}

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/smoker.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/smoker.json
@@ -1,0 +1,27 @@
+{
+    "type": "modern_industrialization:assembler",
+    "eu": 8,
+    "duration": 200,
+    "item_inputs": [
+        {
+            "item": "minecraft:furnace",
+            "amount": 1
+        },
+        {
+            "tag": "minecraft:planks",
+            "amount": 4
+        }
+    ],
+    "fluid_inputs": [
+        {
+            "fluid": "modern_industrialization:creosote",
+            "amount": 100
+        }
+    ],
+    "item_outputs": [
+        {
+            "item": "minecraft:smoker",
+            "amount": 2
+        }
+    ]
+}

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/stonecutter.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/assembler/stonecutter.json
@@ -1,0 +1,21 @@
+{
+    "type": "modern_industrialization:assembler",
+    "eu": 8,
+    "duration": 200,
+    "item_inputs": [
+        {
+            "item": "modern_industrialization:invar_rotary_blade",
+            "amount": 1
+        },
+        {
+            "item": "minecraft:stone",
+            "amount": 3
+        }
+    ],
+    "item_outputs": [
+        {
+            "item": "minecraft:stonecutter",
+            "amount": 2
+        }
+    ]
+}

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/packer/book.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/packer/book.json
@@ -1,0 +1,21 @@
+{
+  "type": "modern_industrialization:packer",
+  "eu": 2,
+  "duration": 100,
+  "item_inputs": [
+    {
+      "item": "minecraft:paper",
+      "amount": 3
+    },
+    {
+      "item": "minecraft:leather",
+      "amount": 1
+    }
+  ],
+  "item_outputs": [
+    {
+      "item": "minecraft:book",
+      "amount": 1
+    }
+  ]
+}

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/packer/brewing_stand.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/packer/brewing_stand.json
@@ -1,7 +1,7 @@
 {
-    "type": "modern_industrialization:assembler",
-    "eu": 8,
-    "duration": 200,
+    "type": "modern_industrialization:packer",
+    "eu": 2,
+    "duration": 100,
     "item_inputs": [
         {
             "item": "minecraft:blaze_rod",
@@ -15,7 +15,7 @@
     "item_outputs": [
         {
             "item": "minecraft:brewing_stand",
-            "amount": 2
+            "amount": 1
         }
     ]
 }

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/packer/cauldron.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/packer/cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "modern_industrialization:packer",
+  "eu": 2,
+  "duration": 100,
+  "item_inputs": [
+    {
+      "item": "modern_industrialization:steel_curved_plate",
+      "amount": 4
+    },
+    {
+      "item": "modern_industrialization:steel_plate",
+      "amount": 3
+    }
+  ],
+  "item_outputs": [
+    {
+      "item": "minecraft:cauldron",
+      "amount": 2
+    }
+  ]
+}

--- a/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/packer/cauldron.json
+++ b/src/main/resources/data/modern_industrialization/recipes/vanilla_recipes/packer/cauldron.json
@@ -1,15 +1,25 @@
 {
-  "type": "modern_industrialization:packer",
-  "eu": 2,
-  "duration": 100,
+  "type": "modern_industrialization:assembler",
+  "eu": 8,
+  "duration": 200,
   "item_inputs": [
     {
       "item": "modern_industrialization:steel_curved_plate",
       "amount": 4
     },
     {
+      "item": "modern_industrialization:steel_bolt",
+      "amount": 4
+    },
+    {
       "item": "modern_industrialization:steel_plate",
-      "amount": 3
+      "amount": 1
+    }
+  ],
+  "fluid_inputs": [
+    {
+      "item": "modern_industrialization:soldering_alloy",
+      "amount": 100
     }
   ],
   "item_outputs": [


### PR DESCRIPTION
Adding recipes for villager profession blocks, for players that want to build large trading stations or use those blocks for building. Recipes which use wood will have Creosote as a component, to give it a use outside of making lube.