### PR TITLE
Add lignite coal to #minecraft:coals

### DIFF
--- a/src/main/resources/data/minecraft/tags/items/coals.json
+++ b/src/main/resources/data/minecraft/tags/items/coals.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "modern_industrialization:lignite_coal"
+  ]
+}


### PR DESCRIPTION
It's used for the campfire crafting recipe and sort of serves as a common tag for coal. (I'm using it in Adorn's stone torch recipe, for example.)