### PR TITLE
Correctly handle EmiIngredients in drag drop handler

### DIFF
--- a/src/client/java/aztech/modern_industrialization/compat/viewer/impl/emi/MIDragDropHandler.java
+++ b/src/client/java/aztech/modern_industrialization/compat/viewer/impl/emi/MIDragDropHandler.java
@@ -30,8 +30,7 @@ import aztech.modern_industrialization.util.Simulation;
 import com.mojang.blaze3d.vertex.PoseStack;
 import dev.emi.emi.api.EmiDragDropHandler;
 import dev.emi.emi.api.stack.EmiIngredient;
-import dev.emi.emi.api.stack.FluidEmiStack;
-import dev.emi.emi.api.stack.ItemEmiStack;
+import dev.emi.emi.api.stack.EmiStack;
 import java.util.ArrayList;
 import java.util.List;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
@@ -46,6 +45,7 @@ import net.minecraft.client.renderer.Rect2i;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.level.material.Fluid;
 import org.jetbrains.annotations.Nullable;
 
@@ -56,8 +56,11 @@ class MIDragDropHandler implements EmiDragDropHandler<Screen> {
             return false;
         }
 
-        FluidVariant fk = ingredient instanceof FluidEmiStack fs ? FluidVariant.of((Fluid) fs.getKey(), fs.getNbt()) : null;
-        ItemVariant ik = ingredient instanceof ItemEmiStack is ? is.item : null;
+        // Note: might provide peculiar behavior for tags. Checking for size == 1 is an option
+        EmiStack stack = ingredient.getEmiStacks().get(0);
+
+        FluidVariant fk = stack.getKey() instanceof Fluid f ? FluidVariant.of(f, stack.getNbt()) : null;
+        ItemVariant ik = stack.getKey() instanceof Item i ? ItemVariant.of(i, stack.getNbt()) : null;
         @Nullable
         GuiEventListener element = gui.getChildAt(mouseX, mouseY).orElse(null);
         if (element instanceof ReiDraggable dw) {
@@ -101,8 +104,10 @@ class MIDragDropHandler implements EmiDragDropHandler<Screen> {
         }
 
         List<Rect2i> bounds = new ArrayList<>();
-        FluidVariant fk = ingredient instanceof FluidEmiStack fs ? FluidVariant.of((Fluid) fs.getKey(), fs.getNbt()) : null;
-        ItemVariant ik = ingredient instanceof ItemEmiStack is ? is.item : null;
+        EmiStack stack = ingredient.getEmiStacks().get(0);
+
+        FluidVariant fk = stack.getKey() instanceof Fluid f ? FluidVariant.of(f, stack.getNbt()) : null;
+        ItemVariant ik = stack.getKey() instanceof Item i ? ItemVariant.of(i, stack.getNbt()) : null;
         for (GuiEventListener element : gui.children()) {
             if (element instanceof AbstractWidget cw && element instanceof ReiDraggable dw) {
                 if (ik != null && dw.dragItem(ik, Simulation.SIMULATE)) {


### PR DESCRIPTION
Grabs the first stack from the ingredient instead of assuming it is equivalent. This notably lets favorites, craftables, etc which implement `EmiIngredient` themselves be used to lock slots like normal.  Also depends less on implementation types and instead on generic fluid and item keys, which can be more safe. Originally this PR was going to include an implementation for dropping stacks with recipe context (`EmiApi.getRecipeContext(ingredient)`) to lock a full recipe's set of slots, but I was unable to get my language server to cooperate with MI, and had to write all this by hand and compile CLI (so these imports were written by hand, and I didn't want to do many more).