### PR TITLE
Improve machine hull upgrade tooltip

### DIFF
--- a/src/generated/resources/assets/modern_industrialization/lang/en_us.json
+++ b/src/generated/resources/assets/modern_industrialization/lang/en_us.json
@@ -1447,7 +1447,7 @@
   "text.modern_industrialization.AcceptLowAndHighPressure": "Accepts %s, %s, %s and %s",
   "text.modern_industrialization.AcceptLowOrHighPressure": "Only accepts %s and %s",
   "text.modern_industrialization.AcceptSingleFluid": "Consumes %s and produces %s per mb",
-  "text.modern_industrialization.AcceptsCasings": "Change casing to connect higher tier cables.",
+  "text.modern_industrialization.AcceptsCasings": "Change machine hull to connect higher tier cables.",
   "text.modern_industrialization.AcceptsSteam": "Accepts Steam (1 mb \u003d 1 EU)",
   "text.modern_industrialization.AcceptsSteamToo": "Also Accepts Steam (1 mb \u003d 1 EU)",
   "text.modern_industrialization.AcceptsUpgrades": "Add upgrades to increase max processing EU/t.",


### PR DESCRIPTION
The previous tooltip said it allows you to place a casing to upgrade the machine's casing. Casings will not go into the slot, but machine hulls do. Therefore, it allows you to place a machine hull to upgrade the machine's machine hull.
#458