### PR TITLE
Adding Biome Process Condition

### DIFF
--- a/docs/ADDING_RECIPES.md
+++ b/docs/ADDING_RECIPES.md
@@ -37,6 +37,7 @@ ServerEvents.recipes(event => {
 The easiest way to add process conditions is via KubeJS, similarly to how inputs and outputs are added.
 Here is the list of currently supported conditions:
 - `dimension(dimension key)`: Requires the machine to be in the specified dimension.
+- `biome(biome key)`: Requires the machine to be in the specified biome.
 - `adjacentBlock(block, position)`: Requires a specific block to be next to the machine.
   - Position indicates where the block should be.
   - For multiblocks, the position is always relative to the controller.

--- a/src/generated/resources/assets/modern_industrialization/lang/en_us.json
+++ b/src/generated/resources/assets/modern_industrialization/lang/en_us.json
@@ -1608,6 +1608,7 @@
   "text.modern_industrialization.Progress": "Progress : %s",
   "text.modern_industrialization.PutMotorToUpgrade": "Put any Motor here to improve Item Pipe Speed",
   "text.modern_industrialization.RemAbsorption": "Remaining Absorption : %d / %d ",
+  "text.modern_industrialization.RequiresBiome": "Requires biome: %s",
   "text.modern_industrialization.RequiresBlockBehind": "Requires block behind machine: %s",
   "text.modern_industrialization.RequiresBlockBelow": "Requires block below machine: %s",
   "text.modern_industrialization.RequiresDimension": "Requires dimension: %s",

--- a/src/generated/resources/assets/modern_industrialization/lang/untranslated/ko_kr.json
+++ b/src/generated/resources/assets/modern_industrialization/lang/untranslated/ko_kr.json
@@ -1,5 +1,5 @@
 {
-  "__summary": "1001 ok, 651 missing, 367 unused",
+  "__summary": "1001 ok, 652 missing, 367 unused",
   "advancements.modern_industrialization.advanced_upgrade": "기계 빠르게-빠르게",
   "advancements.modern_industrialization.advanced_upgrade.description": "발전된 업그레이드를 제작하세요",
   "advancements.modern_industrialization.analog_circuit": "RLC 회로",
@@ -1819,6 +1819,7 @@
   "text.modern_industrialization.Progress": "[UNTRANSLATED] Progress : %s",
   "text.modern_industrialization.PutMotorToUpgrade": "[UNTRANSLATED] Put any Motor here to improve Item Pipe Speed",
   "text.modern_industrialization.RemAbsorption": "[UNTRANSLATED] Remaining Absorption : %d / %d ",
+  "text.modern_industrialization.RequiresBiome": "[UNTRANSLATED] Requires biome: %s",
   "text.modern_industrialization.RequiresBlockBehind": "[UNTRANSLATED] Requires block behind machine: %s",
   "text.modern_industrialization.RequiresBlockBelow": "[UNTRANSLATED] Requires block below machine: %s",
   "text.modern_industrialization.RequiresDimension": "[UNTRANSLATED] Requires dimension: %s",

--- a/src/generated/resources/assets/modern_industrialization/lang/untranslated/pt_br.json
+++ b/src/generated/resources/assets/modern_industrialization/lang/untranslated/pt_br.json
@@ -1,5 +1,5 @@
 {
-  "__summary": "1304 ok, 348 missing, 2 unused",
+  "__summary": "1304 ok, 349 missing, 2 unused",
   "advancements.modern_industrialization.advanced_upgrade": "Aceleração²",
   "advancements.modern_industrialization.advanced_upgrade.description": "Fabrique uma Melhoria Avançada",
   "advancements.modern_industrialization.analog_circuit": "Circuitos RLC",
@@ -1611,6 +1611,7 @@
   "text.modern_industrialization.Progress": "Progresso : %s",
   "text.modern_industrialization.PutMotorToUpgrade": "Coloque qualquer motor para melhorar a velocidade do Tubo de Items",
   "text.modern_industrialization.RemAbsorption": "Absorção Restante : %d / %d ",
+  "text.modern_industrialization.RequiresBiome": "[UNTRANSLATED] Requires biome: %s",
   "text.modern_industrialization.RequiresBlockBehind": "[UNTRANSLATED] Requires block behind machine: %s",
   "text.modern_industrialization.RequiresBlockBelow": "[UNTRANSLATED] Requires block below machine: %s",
   "text.modern_industrialization.RequiresDimension": "[UNTRANSLATED] Requires dimension: %s",

--- a/src/generated/resources/assets/modern_industrialization/lang/untranslated/ru_ru.json
+++ b/src/generated/resources/assets/modern_industrialization/lang/untranslated/ru_ru.json
@@ -1,5 +1,5 @@
 {
-  "__summary": "1304 ok, 348 missing, 2 unused",
+  "__summary": "1304 ok, 349 missing, 2 unused",
   "advancements.modern_industrialization.advanced_upgrade": "Станочное ускорение-разгон",
   "advancements.modern_industrialization.advanced_upgrade.description": "Создай усовершенствованную модернизацию",
   "advancements.modern_industrialization.analog_circuit": "РИК-микросхемы",
@@ -1611,6 +1611,7 @@
   "text.modern_industrialization.Progress": "Прогресс: %s",
   "text.modern_industrialization.PutMotorToUpgrade": "Положи сюда какой-нибудь Мотор, чтобы улучшить Скорость предметной трубы",
   "text.modern_industrialization.RemAbsorption": "Осталось поглощения: %d / %d",
+  "text.modern_industrialization.RequiresBiome": "[UNTRANSLATED] Requires biome: %s",
   "text.modern_industrialization.RequiresBlockBehind": "[UNTRANSLATED] Requires block behind machine: %s",
   "text.modern_industrialization.RequiresBlockBelow": "[UNTRANSLATED] Requires block below machine: %s",
   "text.modern_industrialization.RequiresDimension": "[UNTRANSLATED] Requires dimension: %s",

--- a/src/generated/resources/assets/modern_industrialization/lang/untranslated/zh_cn.json
+++ b/src/generated/resources/assets/modern_industrialization/lang/untranslated/zh_cn.json
@@ -1,5 +1,5 @@
 {
-  "__summary": "1004 ok, 648 missing, 0 unused",
+  "__summary": "1004 ok, 649 missing, 0 unused",
   "advancements.modern_industrialization.advanced_upgrade": "机器再加速",
   "advancements.modern_industrialization.advanced_upgrade.description": "制作进阶升级",
   "advancements.modern_industrialization.analog_circuit": "RLC电路",
@@ -1609,6 +1609,7 @@
   "text.modern_industrialization.Progress": "[UNTRANSLATED] Progress : %s",
   "text.modern_industrialization.PutMotorToUpgrade": "[UNTRANSLATED] Put any Motor here to improve Item Pipe Speed",
   "text.modern_industrialization.RemAbsorption": "[UNTRANSLATED] Remaining Absorption : %d / %d ",
+  "text.modern_industrialization.RequiresBiome": "[UNTRANSLATED] Requires biome: %s",
   "text.modern_industrialization.RequiresBlockBehind": "[UNTRANSLATED] Requires block behind machine: %s",
   "text.modern_industrialization.RequiresBlockBelow": "[UNTRANSLATED] Requires block below machine: %s",
   "text.modern_industrialization.RequiresDimension": "[UNTRANSLATED] Requires dimension: %s",

--- a/src/generated/resources/assets/modern_industrialization/lang/untranslated/zh_tw.json
+++ b/src/generated/resources/assets/modern_industrialization/lang/untranslated/zh_tw.json
@@ -1,5 +1,5 @@
 {
-  "__summary": "411 ok, 1241 missing, 273 unused",
+  "__summary": "411 ok, 1242 missing, 273 unused",
   "advancements.modern_industrialization.advanced_upgrade": "[UNTRANSLATED] Machine Speedup-Speedup",
   "advancements.modern_industrialization.advanced_upgrade.description": "[UNTRANSLATED] Craft a Advanced Upgrade",
   "advancements.modern_industrialization.analog_circuit": "[UNTRANSLATED] RLC Circuits",
@@ -1816,6 +1816,7 @@
   "text.modern_industrialization.Progress": "[UNTRANSLATED] Progress : %s",
   "text.modern_industrialization.PutMotorToUpgrade": "[UNTRANSLATED] Put any Motor here to improve Item Pipe Speed",
   "text.modern_industrialization.RemAbsorption": "[UNTRANSLATED] Remaining Absorption : %d / %d ",
+  "text.modern_industrialization.RequiresBiome": "[UNTRANSLATED] Requires biome: %s",
   "text.modern_industrialization.RequiresBlockBehind": "[UNTRANSLATED] Requires block behind machine: %s",
   "text.modern_industrialization.RequiresBlockBelow": "[UNTRANSLATED] Requires block below machine: %s",
   "text.modern_industrialization.RequiresDimension": "[UNTRANSLATED] Requires dimension: %s",

--- a/src/main/java/aztech/modern_industrialization/MIText.java
+++ b/src/main/java/aztech/modern_industrialization/MIText.java
@@ -199,6 +199,7 @@ public enum MIText {
     NotConsumed("Not consumed"),
     Progress("Progress : %s"),
     RemAbsorption("Remaining Absorption : %d / %d "),
+    RequiresBiome("Requires biome: %s"),
     RequiresBlockBelow("Requires block below machine: %s"),
     RequiresBlockBehind("Requires block behind machine: %s"),
     RequiresDimension("Requires dimension: %s"),

--- a/src/main/java/aztech/modern_industrialization/compat/kubejs/recipe/ProcessConditionHelper.java
+++ b/src/main/java/aztech/modern_industrialization/compat/kubejs/recipe/ProcessConditionHelper.java
@@ -24,6 +24,7 @@
 package aztech.modern_industrialization.compat.kubejs.recipe;
 
 import aztech.modern_industrialization.machines.recipe.condition.AdjacentBlockProcessCondition;
+import aztech.modern_industrialization.machines.recipe.condition.BiomeProcessCondition;
 import aztech.modern_industrialization.machines.recipe.condition.DimensionProcessCondition;
 import aztech.modern_industrialization.machines.recipe.condition.MachineProcessCondition;
 import net.minecraft.resources.ResourceLocation;
@@ -38,5 +39,9 @@ public interface ProcessConditionHelper {
 
     default ProcessConditionHelper adjacentBlock(Block block, String relativePosition) {
         return processCondition(new AdjacentBlockProcessCondition(block, relativePosition));
+    }
+
+    default ProcessConditionHelper biome(ResourceLocation biome) {
+        return processCondition(new BiomeProcessCondition(biome));
     }
 }

--- a/src/main/java/aztech/modern_industrialization/machines/recipe/condition/BiomeProcessCondition.java
+++ b/src/main/java/aztech/modern_industrialization/machines/recipe/condition/BiomeProcessCondition.java
@@ -1,0 +1,76 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Azercoco & Technici4n
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package aztech.modern_industrialization.machines.recipe.condition;
+
+import aztech.modern_industrialization.MIText;
+import aztech.modern_industrialization.machines.recipe.MachineRecipe;
+import com.google.gson.JsonObject;
+import java.util.List;
+import net.minecraft.core.Registry;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.level.biome.Biome;
+
+public class BiomeProcessCondition implements MachineProcessCondition {
+    public static final BiomeProcessCondition.Serde SERIALIZER = new BiomeProcessCondition.Serde();
+    private final ResourceKey<Biome> biome;
+
+    public BiomeProcessCondition(ResourceLocation biome) {
+        this.biome = ResourceKey.create(Registry.BIOME_REGISTRY, biome);
+    }
+
+    @Override
+    public boolean canProcessRecipe(Context context, MachineRecipe recipe) {
+        var entityBiome = context.getLevel().getBiome(context.getBlockEntity().getBlockPos());
+        return entityBiome.is(biome);
+    }
+
+    @Override
+    public void appendDescription(List<Component> list) {
+        var loc = biome.location();
+        var biomeComponent = Component.translatable("biome.%s.%s".formatted(loc.getNamespace(), loc.getPath()));
+        list.add(MIText.RequiresBiome.text(biomeComponent));
+    }
+
+    @Override
+    public Serializer<?> getSerializer() {
+        return SERIALIZER;
+    }
+
+    private static class Serde implements Serializer<BiomeProcessCondition> {
+        @Override
+        public BiomeProcessCondition fromJson(JsonObject json) {
+            return new BiomeProcessCondition(new ResourceLocation(GsonHelper.getAsString(json, "biome")));
+        }
+
+        @Override
+        public JsonObject toJson(BiomeProcessCondition condition) {
+            var obj = new JsonObject();
+            obj.addProperty("biome", condition.biome.location().toString());
+            return obj;
+        }
+    }
+}

--- a/src/main/java/aztech/modern_industrialization/machines/recipe/condition/MachineProcessConditions.java
+++ b/src/main/java/aztech/modern_industrialization/machines/recipe/condition/MachineProcessConditions.java
@@ -52,5 +52,6 @@ public final class MachineProcessConditions {
     static {
         register(new MIIdentifier("dimension"), DimensionProcessCondition.SERIALIZER);
         register(new MIIdentifier("adjacent_block"), AdjacentBlockProcessCondition.SERIALIZER);
+        register(new MIIdentifier("biome"), BiomeProcessCondition.SERIALIZER);
     }
 }


### PR DESCRIPTION
### New Biome Process Condition
This adds a new biome process condition which allows a mod pack dev to use KubeJS to restrict a multiblock machine recipe to only work in a specific biome. This opens up the possibilities for devs to require players to setup quarries in different biomes to acquire biome specific resources.

**Example**
```javascript
ServerEvents.recipes(event => {
    event.remove({id: "modern_industrialization:quarry/bronze"})
    event.recipes.modern_industrialization.quarry(4, 600)
        .itemIn("modern_industrialization:bronze_drill", 0.04)
        .itemOut("minecraft:coal_ore")
        .biome("jungle")
})
```
This example produces a recipe that requires a quarry using a bronze drill to only produce coal ore when placed in the jungle biome. The recipe description is updated to show "Requires biome: <name>"
![image](https://user-images.githubusercontent.com/19756038/229997008-eb5bba05-59ee-4d3a-9241-3f4bb92acaa9.png)

Building and running the quarry in a jungle biome results in the recipe functioning.
![image](https://user-images.githubusercontent.com/19756038/229997188-5d4f943a-05f8-4ac0-89e2-acff15fe9296.png)

Building and running the quarry in a forest (or any other biome) results in the recipe failing to start.
![image](https://user-images.githubusercontent.com/19756038/229997288-95f20431-8fdc-4f2d-b647-2f4acff89e2a.png)

In the recipes documentation a new line is added showing the existence of the biome condition.
![image](https://user-images.githubusercontent.com/19756038/229998157-5d45c587-5599-4a02-b5f6-eb03c38c8c5a.png)
