### PR TITLE
Add `extra_datagen_resources` folder for runtime datagen

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,27 @@ MI can generate most of these resources for you if you ask it to.
   - This will make sure that MI will automatically load the resources generated in the previous step.
 - Profit!
 
+#### More info regarding runtime datagen
+Runtime datagen works by running the data generators during the end of MI startup.
+- It uses `modern_industrialization/runtime_datagen` to produce all the files that are automatically generated.
+  - These files include loot tables, most recipes, or material textures, for example.
+- The files that are **different** from those in the jar then get copied to `modern_industrialization/generated_resources`.
+- Finally, MI injects a hidden data and resource pack with maximum priority to load these resources into the game.
+
+Runtime datagen will only use the resources from the MI jar and the base vanilla assets.
+**It will not use any resource pack, as it runs too early.**
+
+However, files can be placed in the `modern_industrialization/extra_datagen_resources` folder if they are needed during datagen,
+and they take precedence over the files in the MI jar.
+At the moment, this only works for textures.
+Here are some examples to get you started:
+- Placing a texture in `modern_industrialization/extra_datagen_resources/assets/modern_industrialization/textures/materialsets/common/plate.png`
+  will change the texture of most plates.
+- The `datagen_texture_overrides` exists to manually override textures produced by datagen, for example specific material textures.
+  Placing a texture in `modern_industrialization/extra_datagen_resources/assets/modern_industrialization/datagen_texture_overrides/item/aluminum_plate.png`
+  will change the texture of the aluminum plate only.
+- Refer to the contents of the MI .jar for more details on the file structure.
+
 ### Adding new machines
 Refer to [ADDING_MACHINES.md](ADDING_MACHINES.md) for more information on how to add machines via KubeJS.
 

--- a/src/main/java/aztech/modern_industrialization/misc/runtime_datagen/RuntimeDataGen.java
+++ b/src/main/java/aztech/modern_industrialization/misc/runtime_datagen/RuntimeDataGen.java
@@ -47,6 +47,18 @@ public class RuntimeDataGen {
 
     private static void runInner(Consumer<FabricDataGenerator> config) throws Exception {
         var miFolder = FabricLoader.getInstance().getGameDir().resolve("modern_industrialization");
+
+        // Create some relevant texture folders because I'm sure some people will forget it
+        var datagenOverridesFolder = miFolder.resolve("extra_datagen_resources");
+        Files.createDirectories(datagenOverridesFolder
+                .resolve("assets")
+                .resolve("modern_industrialization")
+                .resolve("textures"));
+        Files.createDirectories(datagenOverridesFolder
+                .resolve("assets")
+                .resolve("modern_industrialization")
+                .resolve("datagen_texture_overrides"));
+
         var dataOutput = miFolder.resolve("runtime_datagen");
 
         ModernIndustrialization.LOGGER.info("Starting MI runtime data generation");


### PR DESCRIPTION
Fixes #475 and fixes #477 by introducing a custom folder that will override any resource from the MC or MI jar.