### PR TITLE
Add null check in `PipeColorProvider#getColor`

### DIFF
--- a/src/client/java/aztech/modern_industrialization/pipes/impl/PipeColorProvider.java
+++ b/src/client/java/aztech/modern_industrialization/pipes/impl/PipeColorProvider.java
@@ -33,7 +33,7 @@ import net.minecraft.world.level.block.state.BlockState;
 public class PipeColorProvider implements BlockColor {
     @Override
     public int getColor(BlockState state, BlockAndTintGetter world, BlockPos pos, int tintIndex) {
-        if (world.getBlockEntity(pos) instanceof PipeBlockEntity) {
+        if (world != null && pos != null && world.getBlockEntity(pos) instanceof PipeBlockEntity) {
             PipeBlockEntity entity = (PipeBlockEntity) world.getBlockEntity(pos);
             if (entity == null)
                 return -1;


### PR DESCRIPTION
This pull request fixes #512 by adding a null check for both the world and position arguments in `PipeColorProvider#getColor`. If either argument is `null`, the method will simply return `-1`.
```diff
    @Override
    public int getColor(BlockState state, BlockAndTintGetter world, BlockPos pos, int tintIndex) {
-       if (world.getBlockEntity(pos) instanceof PipeBlockEntity) {
+       if (world != null && pos != null && world.getBlockEntity(pos) instanceof PipeBlockEntity) {
            ...
        }
        return -1;
    }
```