### PR TITLE
Unhardcode cable tiers.

### DIFF
--- a/src/client/java/aztech/modern_industrialization/compat/waila/client/PipeComponentProvider.java
+++ b/src/client/java/aztech/modern_industrialization/compat/waila/client/PipeComponentProvider.java
@@ -142,7 +142,7 @@ public class PipeComponentProvider implements IBlockComponentProvider {
                 tooltip.addLine(new PairComponent(
                         new WrappedComponent(MIText.NetworkTier.text()),
                         new CenteredTextComponent(
-                                MIPipes.ELECTRICITY_PIPE_TIER.get(MIPipes.INSTANCE.getPipeItem(shape.type)).englishNameComponent
+                                MIPipes.ELECTRICITY_PIPE_TIER.get(MIPipes.INSTANCE.getPipeItem(shape.type)).englishTextComponent()
                                         .copy().withStyle(MITooltips.NUMBER_TEXT))));
 
                 // EU/t

--- a/src/main/java/aztech/modern_industrialization/MITooltips.java
+++ b/src/main/java/aztech/modern_industrialization/MITooltips.java
@@ -178,7 +178,7 @@ public class MITooltips {
     public static final TooltipAttachment CABLES = TooltipAttachment
             .of((item) -> item instanceof PipeItem pipe && MIPipes.ELECTRICITY_PIPE_TIER.containsKey(pipe), itemStack -> {
                 var tier = MIPipes.ELECTRICITY_PIPE_TIER.get((PipeItem) itemStack.getItem());
-                return new Line(MIText.EuCable).arg(tier.englishName).arg(tier.getMaxTransfer(), EU_PER_TICK_PARSER).build();
+                return new Line(MIText.EuCable).arg(tier.englishName()).arg(tier.maxTransfer(), EU_PER_TICK_PARSER).build();
             });
 
     public static final TooltipAttachment COILS = TooltipAttachment.of(

--- a/src/main/java/aztech/modern_industrialization/api/energy/CableTier.java
+++ b/src/main/java/aztech/modern_industrialization/api/energy/CableTier.java
@@ -24,62 +24,64 @@
 package aztech.modern_industrialization.api.energy;
 
 import aztech.modern_industrialization.MIText;
-import net.minecraft.network.chat.Component;
+import java.util.Objects;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import javax.annotation.Nullable;
+import net.minecraft.network.chat.MutableComponent;
 
-public enum CableTier {
-    LV("LV", "lv", 32, MIText.CableTierLV),
-    MV("MV", "mv", 32 * 4, MIText.CableTierMV),
-    HV("HV", "hv", 32 * 4 * 8, MIText.CableTierHV),
-    EV("EV", "ev", 32 * 4 * 8 * 8, MIText.CableTierEV),
-    SUPERCONDUCTOR("Superconductor", "superconductor", 128000000, MIText.CableTierSuperconductor);
+/**
+ * A single tier of cables.
+ */
+public interface CableTier extends Comparable<CableTier> {
+    SortedSet<CableTier> TIERS = new TreeSet<>();
 
-    public final String englishName;
-    public final String name;
-    public final long eu;
-
-    public final String translationKey;
-    public final Component englishNameComponent;
-
-    CableTier(String englishName, String name, long eu, MIText englishNameComponent) {
-        this.englishName = englishName;
-        this.name = name;
-        this.eu = eu;
-        this.translationKey = "text.modern_industrialization.cable_tier_" + name;
-        this.englishNameComponent = englishNameComponent.text();
-    }
-
-    public static CableTier getByName(String tier) {
-        for (CableTier cableTier : values()) {
-            if (cableTier.name.equals(tier)) {
-                return cableTier;
-            }
+    /**
+     * Gets a table tier by internal name.
+     *
+     * @param name The internal name of the tier, e.g. 'LV'.
+     * @return If it exists, the added cable tier; otherwise, <code>null</code>.
+     */
+    static @Nullable CableTier getByName(String name) {
+        for (var tier : TIERS) {
+            if (Objects.equals(tier.name(), name))
+                return tier;
         }
+
         return null;
     }
+
+    static CableTier create(String name, String englishName, long eu, MutableComponent text) {
+        return new CableTierImpl(name, englishName, eu, eu * 8, text);
+    }
+
+    static CableTier create(String name, String englishName, long eu, long maxTransfer, MutableComponent text) {
+        return new CableTierImpl(name, englishName, eu, maxTransfer, text);
+    }
+
+    CableTier LV = create("lv", "LV", 32, MIText.CableTierLV.text());
+    CableTier MV = create("mv", "MV", 32 * 4, MIText.CableTierMV.text());
+    CableTier HV = create("hv", "HV", 32 * 4 * 8, MIText.CableTierHV.text());
+    CableTier EV = create("ev", "EV", 32 * 4 * 8 * 8, MIText.CableTierEV.text());
+    CableTier SUPERCONDUCTOR = create("superconductor", "SUPERCONDUCTOR", 128_000_000, MIText.CableTierSuperconductor.text());
+
+    /** The internal name for this tier. */
+    String name();
+
+    /** The English localised name for this tier. */
+    String englishName();
+
+    // TODO: kill this brutally
+    /** The English text component for this tier. */
+    MutableComponent englishTextComponent();
+
+    long eu();
 
     /**
      * @return The total EU/t transferred by this tier of network. The same number
      *         is also the internal storage of every node.
      */
-    public long getMaxTransfer() {
-        return eu * 8;
-    }
-
-    public long getEu() {
-        return eu;
-    }
-
-    @Override
-    public String toString() {
-        return name;
-    }
-
-    public static final CableTier getTier(String name) {
-        for (CableTier tier : CableTier.values()) {
-            if (tier.name.equals(name)) {
-                return tier;
-            }
-        }
-        return null;
+    default long maxTransfer() {
+        return eu() * 8;
     }
 }

--- a/src/main/java/aztech/modern_industrialization/api/energy/CableTier.java
+++ b/src/main/java/aztech/modern_industrialization/api/energy/CableTier.java
@@ -24,6 +24,8 @@
 package aztech.modern_industrialization.api.energy;
 
 import aztech.modern_industrialization.MIText;
+
+import java.util.Comparator;
 import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -34,8 +36,8 @@ import org.jetbrains.annotations.Nullable;
 /**
  * A single tier of cables.
  */
-public interface CableTier extends Comparable<CableTier> {
-    SortedSet<CableTier> TIERS = new TreeSet<>();
+public interface CableTier {
+    SortedSet<CableTier> TIERS = new TreeSet<>(Comparator.comparingLong(CableTier::eu));
 
     /**
      * Gets a table tier by internal name.

--- a/src/main/java/aztech/modern_industrialization/api/energy/CableTier.java
+++ b/src/main/java/aztech/modern_industrialization/api/energy/CableTier.java
@@ -27,8 +27,9 @@ import aztech.modern_industrialization.MIText;
 import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import javax.annotation.Nullable;
 import net.minecraft.network.chat.MutableComponent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A single tier of cables.
@@ -42,7 +43,7 @@ public interface CableTier extends Comparable<CableTier> {
      * @param name The internal name of the tier, e.g. 'LV'.
      * @return If it exists, the added cable tier; otherwise, <code>null</code>.
      */
-    static @Nullable CableTier getByName(String name) {
+    static @Nullable CableTier getByName(@NotNull String name) {
         for (var tier : TIERS) {
             if (Objects.equals(tier.name(), name))
                 return tier;

--- a/src/main/java/aztech/modern_industrialization/api/energy/CableTierImpl.java
+++ b/src/main/java/aztech/modern_industrialization/api/energy/CableTierImpl.java
@@ -23,43 +23,20 @@
  */
 package aztech.modern_industrialization.api.energy;
 
-import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
-import org.jetbrains.annotations.ApiStatus;
-import team.reborn.energy.api.EnergyStorage;
+import net.minecraft.network.chat.MutableComponent;
+import org.jetbrains.annotations.NotNull;
 
-public interface MIEnergyStorage extends EnergyStorage {
-    boolean canConnect(CableTier cableTier);
-
-    /**
-     * Overload of {@link #canConnect(CableTier)} that's easier to access by reflection.
-     */
-    @ApiStatus.NonExtendable
-    default boolean canConnect(String cableTier) {
-        var tier = CableTier.getByName(cableTier);
-        return canConnect(tier);
-    }
-
-    interface NoExtract extends MIEnergyStorage {
-        @Override
-        default boolean supportsExtraction() {
-            return false;
-        }
-
-        @Override
-        default long extract(long maxAmount, TransactionContext transaction) {
-            return 0;
-        }
-    }
-
-    interface NoInsert extends MIEnergyStorage {
-        @Override
-        default boolean supportsInsertion() {
-            return false;
-        }
-
-        @Override
-        default long insert(long maxAmount, TransactionContext transaction) {
-            return 0;
-        }
+/**
+ * Record-based implementation of a CableTier. Use the utility functions on the interface instead.
+ */
+record CableTierImpl(
+        String name,
+        String englishName,
+        long eu,
+        long maxTransfer,
+        MutableComponent englishTextComponent) implements CableTier {
+    @Override
+    public int compareTo(@NotNull CableTier o) {
+        return Long.compare(eu, o.eu());
     }
 }

--- a/src/main/java/aztech/modern_industrialization/api/energy/CableTierImpl.java
+++ b/src/main/java/aztech/modern_industrialization/api/energy/CableTierImpl.java
@@ -35,8 +35,4 @@ record CableTierImpl(
         long eu,
         long maxTransfer,
         MutableComponent englishTextComponent) implements CableTier {
-    @Override
-    public int compareTo(@NotNull CableTier o) {
-        return Long.compare(eu, o.eu());
-    }
 }

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/AbstractStorageMachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/AbstractStorageMachineBlockEntity.java
@@ -35,8 +35,6 @@ import aztech.modern_industrialization.machines.components.OrientationComponent;
 import aztech.modern_industrialization.machines.gui.MachineGuiParameters;
 import aztech.modern_industrialization.machines.guicomponents.EnergyBar;
 import aztech.modern_industrialization.machines.helper.EnergyHelper;
-import aztech.modern_industrialization.machines.models.MachineCasing;
-import aztech.modern_industrialization.machines.models.MachineCasings;
 import aztech.modern_industrialization.machines.models.MachineModelClientData;
 import aztech.modern_industrialization.util.Simulation;
 import aztech.modern_industrialization.util.Tickable;
@@ -89,10 +87,6 @@ public abstract class AbstractStorageMachineBlockEntity extends MachineBlockEnti
     @Override
     public MIInventory getInventory() {
         return MIInventory.EMPTY;
-    }
-
-    public static MachineCasing getCasingFromTier(CableTier from, CableTier to) {
-        return MachineCasings.casingFromCableTier(from.eu > to.eu ? from : to);
     }
 
     @Override

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/TransformerMachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/TransformerMachineBlockEntity.java
@@ -29,14 +29,20 @@ import aztech.modern_industrialization.machines.BEP;
 public class TransformerMachineBlockEntity extends AbstractStorageMachineBlockEntity {
 
     public TransformerMachineBlockEntity(BEP bep, CableTier from, CableTier to) {
-        super(bep, from, to, getTransformerName(from, to), 200 * Math.min(from.eu, to.eu), from.eu < to.eu);
+        super(
+                bep,
+                from,
+                to,
+                getTransformerName(from, to),
+                200 * Math.min(from.eu(), to.eu()),
+                from.eu() < to.eu());
     }
 
     public static String getTransformerName(CableTier from, CableTier to) {
-        return from.name + "_" + to.name + "_transformer";
+        return from.name() + "_" + to.name() + "_transformer";
     }
 
     public static String getTransformerEnglishName(CableTier from, CableTier to) {
-        return from.englishName + " to " + to.englishName + " Transformer";
+        return from.englishName() + " to " + to.englishName() + " Transformer";
     }
 }

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/EnergyHatch.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/EnergyHatch.java
@@ -45,7 +45,7 @@ public class EnergyHatch extends HatchBlockEntity implements EnergyComponentHold
 
         this.input = input;
 
-        this.energy = new EnergyComponent(this, 30 * 20 * tier.getEu());
+        this.energy = new EnergyComponent(this, 30 * 20 * tier.eu());
         insertable = energy.buildInsertable((CableTier tier2) -> tier2 == tier);
         extractable = energy.buildExtractable((CableTier tier2) -> tier2 == tier);
         EnergyBar.Parameters energyBarParams = new EnergyBar.Parameters(76, 39);

--- a/src/main/java/aztech/modern_industrialization/machines/components/CasingComponent.java
+++ b/src/main/java/aztech/modern_industrialization/machines/components/CasingComponent.java
@@ -63,17 +63,16 @@ public class CasingComponent implements IComponent {
     public CasingComponent(CableTier defaultCasing) {
         this.defaultCasing = defaultCasing;
         this.tierCasing = defaultCasing;
-
     }
 
     @Override
     public void writeNbt(CompoundTag tag) {
-        tag.putString("casing", tierCasing.name);
+        tag.putString("casing", tierCasing.name());
     }
 
     @Override
     public void readNbt(CompoundTag tag) {
-        tierCasing = CableTier.getTier(tag.getString("casing"));
+        tierCasing = CableTier.getByName(tag.getString("casing"));
         if (tierCasing == null) {
             tierCasing = defaultCasing;
         }
@@ -82,12 +81,12 @@ public class CasingComponent implements IComponent {
 
     @Override
     public void writeClientNbt(CompoundTag tag) {
-        tag.putString("casing", tierCasing.name);
+        tag.putString("casing", tierCasing.name());
     }
 
     @Override
     public void readClientNbt(CompoundTag tag) {
-        tierCasing = CableTier.getTier(tag.getString("casing"));
+        tierCasing = CableTier.getByName(tag.getString("casing"));
         if (tierCasing == null) {
             tierCasing = defaultCasing;
         }
@@ -174,6 +173,6 @@ public class CasingComponent implements IComponent {
     }
 
     public long getEuCapacity() {
-        return tierCasing.getEu() * 100;
+        return tierCasing.eu() * 100;
     }
 }

--- a/src/main/java/aztech/modern_industrialization/machines/init/MultiblockHatches.java
+++ b/src/main/java/aztech/modern_industrialization/machines/init/MultiblockHatches.java
@@ -120,8 +120,8 @@ public class MultiblockHatches {
     private static void registerEnergyHatches(CableTier tier) {
         for (int iter = 0; iter < 2; ++iter) {
             boolean input = iter == 0;
-            String machine = tier.name + "_energy_" + (input ? "input" : "output") + "_hatch";
-            String englishName = tier.englishName + " Energy" + (input ? " Input" : " Output") + " Hatch";
+            String machine = tier.name() + "_energy_" + (input ? "input" : "output") + "_hatch";
+            String englishName = tier.englishName() + " Energy" + (input ? " Input" : " Output") + " Hatch";
             MachineRegistrationHelper.registerMachine(englishName, machine, bet -> new EnergyHatch(bet, machine, input, tier),
                     EnergyHatch::registerEnergyApi);
             MachineRegistrationHelper.addMachineModel(machine, "hatch_energy", MachineCasings.casingFromCableTier(tier), true, false, true, false);

--- a/src/main/java/aztech/modern_industrialization/machines/init/SingleBlockSpecialMachines.java
+++ b/src/main/java/aztech/modern_industrialization/machines/init/SingleBlockSpecialMachines.java
@@ -23,6 +23,8 @@
  */
 package aztech.modern_industrialization.machines.init;
 
+import static aztech.modern_industrialization.machines.init.MachineRegistrationHelper.*;
+
 import aztech.modern_industrialization.MIFluids;
 import aztech.modern_industrialization.api.energy.CableTier;
 import aztech.modern_industrialization.machines.MachineBlockEntity;
@@ -35,109 +37,163 @@ public class SingleBlockSpecialMachines {
 
     public static void init() {
 
-        MachineRegistrationHelper.registerMachine("Bronze Boiler", "bronze_boiler", bet -> new BoilerMachineBlockEntity(bet, true),
+        registerMachine("Bronze Boiler", "bronze_boiler", bet -> new BoilerMachineBlockEntity(bet, true),
                 MachineBlockEntity::registerFluidApi, MachineBlockEntity::registerItemApi);
-        MachineRegistrationHelper.registerMachine("Steel Boiler", "steel_boiler", bet -> new BoilerMachineBlockEntity(bet, false),
+        registerMachine("Steel Boiler", "steel_boiler", bet -> new BoilerMachineBlockEntity(bet, false),
                 MachineBlockEntity::registerFluidApi, MachineBlockEntity::registerItemApi);
 
         // TODO: register water pumps in REI?
-        MachineRegistrationHelper.registerMachine("Bronze Water Pump", "bronze_water_pump", bet -> new SteamWaterPumpBlockEntity(bet, true),
+        registerMachine("Bronze Water Pump", "bronze_water_pump", bet -> new SteamWaterPumpBlockEntity(bet, true),
                 MachineBlockEntity::registerFluidApi);
-        MachineRegistrationHelper.registerMachine("Steel Water Pump", "steel_water_pump", bet -> new SteamWaterPumpBlockEntity(bet, false),
+        registerMachine("Steel Water Pump", "steel_water_pump", bet -> new SteamWaterPumpBlockEntity(bet, false),
                 MachineBlockEntity::registerFluidApi);
-        MachineRegistrationHelper.registerMachine("Electric Water Pump", "electric_water_pump", ElectricWaterPumpBlockEntity::new,
+        registerMachine("Electric Water Pump", "electric_water_pump", ElectricWaterPumpBlockEntity::new,
                 MachineBlockEntity::registerFluidApi,
                 ElectricWaterPumpBlockEntity::registerEnergyApi);
 
-        registerTransformers();
-        registerSteamTurbines(32, 128, 512);
-        registerEUStorage();
+        registerTransformer(CableTier.LV, CableTier.MV);
+        registerTransformer(CableTier.MV, CableTier.HV);
+        registerTransformer(CableTier.HV, CableTier.EV);
+        registerTransformer(CableTier.EV, CableTier.SUPERCONDUCTOR);
 
-        MachineRegistrationHelper.registerMachine("Starter Diesel Generator", "starter_diesel_generator",
+        registerSteamTurbine(CableTier.LV, 32, 1600);
+        registerSteamTurbine(CableTier.MV, 128, 3200);
+        registerSteamTurbine(CableTier.HV, 512, 6400);
+
+        registerEnergyStorage(CableTier.LV);
+        registerEnergyStorage(CableTier.MV);
+        registerEnergyStorage(CableTier.HV);
+        registerEnergyStorage(CableTier.EV);
+        registerEnergyStorage(CableTier.SUPERCONDUCTOR);
+
+        registerMachine("Starter Diesel Generator", "starter_diesel_generator",
                 bet -> new EnergyFromFluidMachineBlockEntity(bet, "starter_diesel_generator", CableTier.LV, 4000, 16000,
                         FluidConsumerComponent.ofFluidFuels(64)),
                 MachineBlockEntity::registerFluidApi, EnergyFromFluidMachineBlockEntity::registerEnergyApi);
 
-        MachineRegistrationHelper.registerMachine("Diesel Generator", "diesel_generator",
+        registerMachine("Diesel Generator", "diesel_generator",
                 bet -> new EnergyFromFluidMachineBlockEntity(bet, "diesel_generator", CableTier.MV, 12000, 32000,
                         FluidConsumerComponent.ofFluidFuels(256)),
                 MachineBlockEntity::registerFluidApi, EnergyFromFluidMachineBlockEntity::registerEnergyApi);
 
-        MachineRegistrationHelper.registerMachine("Turbo Diesel Generator", "turbo_diesel_generator",
+        registerMachine("Turbo Diesel Generator", "turbo_diesel_generator",
                 bet -> new EnergyFromFluidMachineBlockEntity(bet, "turbo_diesel_generator", CableTier.HV, 60000, 64000,
                         FluidConsumerComponent.ofFluidFuels(1024)),
                 MachineBlockEntity::registerFluidApi, EnergyFromFluidMachineBlockEntity::registerEnergyApi);
 
-        MachineRegistrationHelper.registerMachine("Configurable Chest", "configurable_chest", ConfigurableChestMachineBlockEntity::new,
+        registerMachine("Configurable Chest", "configurable_chest", ConfigurableChestMachineBlockEntity::new,
                 MachineBlockEntity::registerItemApi);
 
-        MachineRegistrationHelper.registerMachine("Configurable Tank", "configurable_tank", ConfigurableTankMachineBlockEntity::new,
+        registerMachine("Configurable Tank", "configurable_tank", ConfigurableTankMachineBlockEntity::new,
                 MachineBlockEntity::registerFluidApi);
 
-        MachineRegistrationHelper.registerMachine("Replicator", "replicator", ReplicatorMachineBlockEntity::new, MachineBlockEntity::registerFluidApi,
+        registerMachine("Replicator", "replicator", ReplicatorMachineBlockEntity::new, MachineBlockEntity::registerFluidApi,
                 MachineBlockEntity::registerItemApi);
 
-        MachineRegistrationHelper.addModelsForTiers("water_pump", true, true, true, "bronze", "steel", "electric");
-        MachineRegistrationHelper.addMachineModel("bronze_boiler", "boiler", MachineCasings.BRICKED_BRONZE, true, false, false);
-        MachineRegistrationHelper.addMachineModel("steel_boiler", "boiler", MachineCasings.BRICKED_STEEL, true, false, false);
-        MachineRegistrationHelper.addMachineModel("starter_diesel_generator", "diesel_generator", MachineCasings.LV, true, true, true);
-        MachineRegistrationHelper.addMachineModel("diesel_generator", "diesel_generator", MachineCasings.MV, true, true, true);
-        MachineRegistrationHelper.addMachineModel("turbo_diesel_generator", "diesel_generator", MachineCasings.HV, true, true, true);
-        MachineRegistrationHelper.addMachineModel("configurable_chest", "", MachineCasings.STEEL_CRATE, false, false, false, false);
-        MachineRegistrationHelper.addMachineModel("configurable_tank", "", MachineCasings.CONFIGURABLE_TANK, false, false, false, false);
-        MachineRegistrationHelper.addMachineModel("replicator", "replicator", MachineCasings.SUPERCONDUCTOR, true, false, true, true);
-    }
-
-    private static void registerTransformers() {
-        CableTier[] tiers = CableTier.values();
-        for (int i = 0; i < tiers.length - 1; i++) {
-            final CableTier low = tiers[i];
-            final CableTier up = tiers[i + 1];
-
-            String lowToUp = TransformerMachineBlockEntity.getTransformerName(low, up);
-            String lowToUpName = TransformerMachineBlockEntity.getTransformerEnglishName(low, up);
-            MachineRegistrationHelper.registerMachine(lowToUpName, lowToUp, bet -> new TransformerMachineBlockEntity(bet, low, up),
-                    AbstractStorageMachineBlockEntity::registerEnergyApi);
-
-            String upToLow = TransformerMachineBlockEntity.getTransformerName(up, low);
-            String upToLowName = TransformerMachineBlockEntity.getTransformerEnglishName(up, low);
-            MachineRegistrationHelper.registerMachine(upToLowName, upToLow, bet -> new TransformerMachineBlockEntity(bet, up, low),
-                    AbstractStorageMachineBlockEntity::registerEnergyApi);
-
-            MachineRegistrationHelper.addMachineModel(lowToUp, "transformer", getTransformerCasingFromTier(low, up), true, true, true, false);
-            MachineRegistrationHelper.addMachineModel(upToLow, "transformer", getTransformerCasingFromTier(up, low), true, true, true, false);
-        }
+        addModelsForTiers("water_pump", true, true, true, "bronze", "steel", "electric");
+        addMachineModel("bronze_boiler", "boiler", MachineCasings.BRICKED_BRONZE, true, false, false);
+        addMachineModel("steel_boiler", "boiler", MachineCasings.BRICKED_STEEL, true, false, false);
+        addMachineModel("starter_diesel_generator", "diesel_generator", MachineCasings.LV, true, true, true);
+        addMachineModel("diesel_generator", "diesel_generator", MachineCasings.MV, true, true, true);
+        addMachineModel("turbo_diesel_generator", "diesel_generator", MachineCasings.HV, true, true, true);
+        addMachineModel("configurable_chest", "", MachineCasings.STEEL_CRATE, false, false, false, false);
+        addMachineModel("configurable_tank", "", MachineCasings.CONFIGURABLE_TANK, false, false, false, false);
+        addMachineModel("replicator", "replicator", MachineCasings.SUPERCONDUCTOR, true, false, true, true);
     }
 
     public static MachineCasing getTransformerCasingFromTier(CableTier from, CableTier to) {
-        return MachineCasings.casingFromCableTier(from.eu > to.eu ? to : from);
+        return MachineCasings.casingFromCableTier(from.eu() > to.eu() ? to : from);
     }
 
-    private static void registerSteamTurbines(int... maxConsumption) {
-        for (int i = 0; i < maxConsumption.length; i++) {
-            CableTier tier = CableTier.values()[i];
-            String id = tier.name + "_steam_turbine";
-            String englishName = tier.englishName + " Steam Turbine";
-            final int eu = maxConsumption[i];
-            final int fluidCapacity = 16000 * (1 << i);
-            MachineRegistrationHelper.registerMachine(englishName, id,
-                    bet -> new EnergyFromFluidMachineBlockEntity(bet, id, tier, eu * 100L, fluidCapacity, eu,
-                            MIFluids.STEAM.asFluid(), 1),
-                    MachineBlockEntity::registerFluidApi, EnergyFromFluidMachineBlockEntity::registerEnergyApi);
+    /**
+     * Registers a new transformer block for the provided tiers.
+     *
+     * @param base The base tier to transform from.
+     * @param up   The tier to transform upto, or down from.
+     */
+    private static void registerTransformer(CableTier base, CableTier up) {
+        String baseToHigherId = TransformerMachineBlockEntity.getTransformerName(base, up);
+        String higherToBaseId = TransformerMachineBlockEntity.getTransformerName(up, base);
 
-            MachineRegistrationHelper.addMachineModel(id, "steam_turbine", MachineCasings.casingFromCableTier(tier), true, false, false);
-        }
+        registerMachine(
+                TransformerMachineBlockEntity.getTransformerEnglishName(base, up),
+                baseToHigherId,
+                bep -> new TransformerMachineBlockEntity(bep, base, up),
+                AbstractStorageMachineBlockEntity::registerEnergyApi);
+
+        registerMachine(
+                TransformerMachineBlockEntity.getTransformerEnglishName(up, base),
+                higherToBaseId,
+                bep -> new TransformerMachineBlockEntity(bep, up, base),
+                AbstractStorageMachineBlockEntity::registerEnergyApi);
+
+        addMachineModel(
+                baseToHigherId,
+                "transformer",
+                getTransformerCasingFromTier(base, up),
+                true, true, true, false);
+
+        addMachineModel(
+                higherToBaseId,
+                "transformer",
+                getTransformerCasingFromTier(base, up),
+                true, true, true, false);
     }
 
-    private static void registerEUStorage() {
-        for (CableTier tier : CableTier.values()) {
-            String id = tier.name + "_storage_unit";
-            String englishName = tier.englishName + " Storage Unit";
-            MachineRegistrationHelper.registerMachine(englishName, id, bet -> new StorageMachineBlockEntity(bet, tier, id, 60 * 5 * 20 * tier.eu),
-                    AbstractStorageMachineBlockEntity::registerEnergyApi);
+    // TODO: Should maxConsumption and fluidCapacity be based automatically off of tier?
+    /**
+     * Registers a new steam turbine block for the provided tier.
+     *
+     * @param tier           The CableTier this turbine uses.
+     * @param maxConsumption The maximum EU this turbine can output.
+     * @param fluidCapacity  The maximum fluid capacity of this turbine, in droplets.
+     */
+    private static void registerSteamTurbine(
+            CableTier tier,
+            int maxConsumption,
+            int fluidCapacity) {
+        var machineId = tier.name() + "_steam_turbine";
+        var machineEnglishName = tier.englishName() + " Steam Turbine";
 
-            MachineRegistrationHelper.addMachineModel(id, "electric_storage", MachineCasings.casingFromCableTier(tier), true, false, true, false);
-        }
+        registerMachine(
+                machineEnglishName,
+                machineId,
+                bep -> new EnergyFromFluidMachineBlockEntity(
+                        bep,
+                        machineId,
+                        tier,
+                        maxConsumption * 100L,
+                        fluidCapacity,
+                        maxConsumption,
+                        MIFluids.STEAM.asFluid(),
+                        1),
+                MachineBlockEntity::registerFluidApi,
+                EnergyFromFluidMachineBlockEntity::registerEnergyApi);
+
+        addMachineModel(
+                machineId,
+                "steam_turbine",
+                MachineCasings.casingFromCableTier(tier),
+                true, false, false);
     }
 
+    /**
+     * Registers an EU energy storage machine for the specified tier.
+     */
+    private static void registerEnergyStorage(CableTier tier) {
+        var id = tier.name() + "_storage_unit";
+        var englishName = tier.englishName() + " Storage Unit";
+
+        registerMachine(
+                englishName,
+                id,
+                bep -> new StorageMachineBlockEntity(bep, tier, id, 60 * 5 * 20 * tier.eu()),
+                AbstractStorageMachineBlockEntity::registerEnergyApi);
+
+        addMachineModel(
+                id,
+                "electric_storage",
+                MachineCasings.casingFromCableTier(tier),
+                true, false, true, false);
+    }
 }

--- a/src/main/java/aztech/modern_industrialization/pipes/electricity/ElectricityNetwork.java
+++ b/src/main/java/aztech/modern_industrialization/pipes/electricity/ElectricityNetwork.java
@@ -61,13 +61,13 @@ public class ElectricityNetwork extends PipeNetwork {
         storages.removeIf(s -> !s.canConnect(tier));
 
         // Do the transfer
-        long networkCapacity = loadedNodeCount * tier.getMaxTransfer();
+        long networkCapacity = loadedNodeCount * tier.maxTransfer();
         try (var tx = Transaction.openOuter()) {
-            long extractMaxAmount = Math.min(tier.getMaxTransfer(), networkCapacity - networkAmount);
+            long extractMaxAmount = Math.min(tier.maxTransfer(), networkCapacity - networkAmount);
             long extracted = transferForTargets(MIEnergyStorage::extract, storages, extractMaxAmount, tx);
             networkAmount += extracted;
 
-            long insertMaxAmount = Math.min(tier.getMaxTransfer(), networkAmount);
+            long insertMaxAmount = Math.min(tier.maxTransfer(), networkAmount);
             long inserted = transferForTargets(MIEnergyStorage::insert, storages, insertMaxAmount, tx);
             networkAmount -= inserted;
 

--- a/src/main/java/aztech/modern_industrialization/pipes/electricity/ElectricityNetworkNode.java
+++ b/src/main/java/aztech/modern_industrialization/pipes/electricity/ElectricityNetworkNode.java
@@ -147,7 +147,7 @@ public class ElectricityNetworkNode extends PipeNetworkNode {
 
     // Used in the Waila plugin
     private long getMaxTransfer() {
-        return ((ElectricityNetwork) network).tier.getMaxTransfer();
+        return ((ElectricityNetwork) network).tier.maxTransfer();
     }
 
     public InGameInfo collectNetworkInfo() {


### PR DESCRIPTION
This converts ``CableTier`` into an interface, adds a default implementation via a record, and adjusts the code to not rely on enum behaviour. Obviously not finished yet. No clue if it actually works but hey, it compiles.

Points to discuss before merging:

- Adding tiers right now won't really work because transformers and the likes assume that EV<->Superconductor is a thing. 
- Making ``CableTier`` own a ``MutableComponent`` feels kinda gross.
- ``MachineCasings#casingFromCableTier`` needs to be adjusted to support this.
- Adding things like transformers, energy storage, and friends for the cable tier should probnably be exposed publically for addons/KubeJS. 