### PR TITLE
update buildscript + gradle to work on gradle 8.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-    id 'fabric-loom' version '1.0-SNAPSHOT'
+    id 'fabric-loom' version '1.2.7'
     id 'maven-publish'
     id 'com.diffplug.spotless' version '5.14.0'
     id 'com.matthewprenger.cursegradle' version '1.4.0'
     id "com.modrinth.minotaur" version "2.+"
-    id 'io.github.juuxel.loom-quiltflower' version '1.8.0'
+    id 'io.github.juuxel.loom-quiltflower' version '1.10.0'
 }
 
 apply plugin: 'java-library'
@@ -188,11 +188,11 @@ dependencies {
     }
 
     if (project.runtime_itemlist_mod == "emi") {
-        modImplementation("dev.emi:emi:${project.emi_version}+${project.emi_minecraft_version}") {
+        modImplementation("dev.emi:emi-fabric:${project.emi_version}+${project.emi_minecraft_version}") {
             exclude group: "net.fabricmc.fabric-api"
         }
     } else {
-        modCompileOnly("dev.emi:emi:${project.emi_version}+${project.emi_minecraft_version}") {
+        modCompileOnly("dev.emi:emi-fabric:${project.emi_version}+${project.emi_minecraft_version}") {
             exclude group: "net.fabricmc.fabric-api"
         }
     }
@@ -229,6 +229,7 @@ dependencies {
 
     include modApi("teamreborn:energy:${project.tr_energy_version}") {
         exclude(group: "net.fabricmc.fabric-api")
+        exclude group: "net.fabricmc", module: "fabric-loader"
     }
 
     include modImplementation("io.github.ladysnake:PlayerAbilityLib:${project.pal_version}") {
@@ -268,16 +269,28 @@ dependencies {
     }
 }
 
+configurations {
+    // due to a change in newer loom, loader isn't remapped
+    // except some mods pull in an older version of loader that *is* remapped
+    // so it has to be excluded explicitly.
+
+    modRuntimeOnly.exclude group: "net.fabricmc", module: "fabric-loader"
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+
+    withSourcesJar()
+}
+
 processResources {
     inputs.property "version", project.version
 
     filesMatching("fabric.mod.json") {
         expand "version": project.version
     }
-}
-
-loom {
-    splitEnvironmentSourceSets()
 }
 
 sourceSets {
@@ -293,6 +306,8 @@ sourceSets {
 }
 
 loom {
+    splitEnvironmentSourceSets()
+
     accessWidenerPath = file("src/main/resources/modern_industrialization.accesswidener")
     mods {
         moderndynamics {
@@ -331,14 +346,6 @@ tasks.withType(JavaCompile).configureEach {
 
     // Minecraft 1.17 (21w19a) upwards uses Java 16.
     it.options.release = 17
-}
-
-// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-// if it is present.
-// If you remove this task, sources will not be generated.
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = "sources"
-    from sourceSets.main.allSource
 }
 
 jar {
@@ -392,7 +399,7 @@ import com.google.gson.GsonBuilder
 
 final class JsonOrderStep {
     private JsonOrderStep() {}
-    private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().setLenient().setPrettyPrinting().create();
+    private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().setLenient().setPrettyPrinting().create()
 
     static FormatterStep create() {
         return FormatterStep.create(
@@ -401,20 +408,20 @@ final class JsonOrderStep {
                 {
                     new FormatterFunc() {
                         String apply(String input) {
-                            TreeMap<String, Object> jsonMap = GSON.fromJson(input, TreeMap.class);
-                            String sortedJson = GSON.toJson(jsonMap);
-                            String prettyPrinted = sortedJson.replace('\\u0027', '\'');
-                            return prettyPrinted + "\n";
+                            TreeMap<String, Object> jsonMap = GSON.fromJson(input, TreeMap.class)
+                            String sortedJson = GSON.toJson(jsonMap)
+                            String prettyPrinted = sortedJson.replace('\\u0027', '\'')
+                            return prettyPrinted + "\n"
                         }
                     }
                 },
-        );
+        )
     }
 
     private static final class State implements Serializable {
-        private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L
 
-        private final int formatVersion = 1;
+        private final int formatVersion = 1
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.jvmargs=-Xmx1G \
 # Fabric Properties
 	# check these on https://fabricmc.net/use
 	minecraft_version=1.19.2
-	loader_version=0.14.9
+	loader_version=0.14.21
 
 # Mod Properties
 	mod_version=0.0.0-SNAPSHOT
@@ -21,24 +21,24 @@ org.gradle.jvmargs=-Xmx1G \
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 	fabric_version=0.71.0+1.19.2
 	jei_minecraft_version=1.19.2
-	jei_version=11.3.0.260
-	rei_version=9.0.491
+	jei_version=11.6.0.1015
+	rei_version=9.0.493
 	emi_minecraft_version=1.19.2
-	emi_version=0.7.2
-	patchouli_version=1.19.2-76-FABRIC
-	cloth_config_version=7.0.72
+	emi_version=1.0.4
+	patchouli_version=1.19.2-77-FABRIC
+	cloth_config_version=7.0.74
 	wthit_version=5.12.0
-	mod_menu_version=4.0.6
-	tr_energy_version=2.2.0
+	mod_menu_version=4.1.2
+	tr_energy_version=2.3.0
 	magna_version=1.8.1-1.19
 	pal_version=1.6.0
 	megane_api_version=8.1.0
 	megane_runtime_version=8.1.0
 	megane_vanilla_version=8.1.0
-	ae2_version=12.9.3
+	ae2_version=12.9.5
 	no_indium_version=1.1.0+1.19
-	ftb_quests_version=1902.4.11-build.209
+	ftb_quests_version=1902.4.16-build.235
 
-# Set to rei or jei to pick which tooltip mod gets picked at runtime
+# Set to "rei", "jei", or "emi" to pick which tooltip mod gets picked at runtime
 # for the dev environment.
 runtime_itemlist_mod=emi

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/client/java/aztech/modern_industrialization/compat/viewer/impl/ViewerUtil.java
+++ b/src/client/java/aztech/modern_industrialization/compat/viewer/impl/ViewerUtil.java
@@ -26,9 +26,9 @@ package aztech.modern_industrialization.compat.viewer.impl;
 import aztech.modern_industrialization.MIText;
 import aztech.modern_industrialization.util.TextHelper;
 import java.text.DecimalFormat;
-import javax.annotation.Nullable;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import org.jetbrains.annotations.Nullable;
 
 public class ViewerUtil {
     private static final DecimalFormat PROBABILITY_FORMAT = new DecimalFormat("#.#");

--- a/src/client/java/aztech/modern_industrialization/compat/viewer/impl/emi/ViewerCategoryEmi.java
+++ b/src/client/java/aztech/modern_industrialization/compat/viewer/impl/emi/ViewerCategoryEmi.java
@@ -150,7 +150,7 @@ class ViewerCategoryEmi<D> extends EmiRecipeCategory {
                 isFluid = true;
                 hasBackground = false;
                 if (!fluid.isBlank()) {
-                    ing = EmiStack.of(fluid);
+                    ing = EmiStack.of(fluid.getFluid(), fluid.getNbt());
                 }
             } else {
                 throw new IllegalArgumentException("Unknown variant type: " + variant.getClass());
@@ -162,7 +162,7 @@ class ViewerCategoryEmi<D> extends EmiRecipeCategory {
         public ViewerCategory.SlotBuilder fluid(FluidVariant fluid, long amount, float probability) {
             isFluid = true;
             hasBackground = false;
-            ing = EmiStack.of(fluid, amount);
+            ing = EmiStack.of(fluid.getFluid(), fluid.getNbt(), amount);
             processProbability(probability);
             return this;
         }

--- a/src/client/java/aztech/modern_industrialization/compat/viewer/impl/rei/ReiSlotUtil.java
+++ b/src/client/java/aztech/modern_industrialization/compat/viewer/impl/rei/ReiSlotUtil.java
@@ -29,13 +29,13 @@ import dev.architectury.hooks.fluid.fabric.FluidStackHooksFabric;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 import me.shedaniel.rei.api.client.gui.widgets.Tooltip;
 import me.shedaniel.rei.api.common.entry.EntryStack;
 import me.shedaniel.rei.api.common.util.EntryStacks;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariantAttributes;
 import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.Nullable;
 
 public class ReiSlotUtil {
     private ReiSlotUtil() {


### PR DESCRIPTION
- update loom to 1.2.7
- apply some tape to some mods that use really ancient fabric loader versions (TR energy) that loom inexplicitly decided to break with 1.2.x
- bump wrapper version to 8.1.1, so now gradle can run under a java 19/20/etc host
- add toolchain config so that if youre using java 20 host you can avoid explosions
- switch out some ``javax.annotations`` for jetbrains ones. JB is used in the rest of the project and i assume newer loom stops putting JSR305 on compileClasspath for now.

also bumps some deps for good measure whilst i was there (except wthit because that has API changes that seem to be being tracked in a different PR.) fabric api also isn't bumped because it inexplicitly explodes with mixin errors.

separated out from #518. 