### PR TITLE
rename getStack -> getRealStack to avoid remapping issues.

### DIFF
--- a/src/main/java/aztech/modern_industrialization/inventory/ConfigurableItemStack.java
+++ b/src/main/java/aztech/modern_industrialization/inventory/ConfigurableItemStack.java
@@ -212,12 +212,12 @@ public class ConfigurableItemStack extends AbstractConfigurableStack<Item, ItemV
         }
 
         @Override
-        protected ItemStack getStack() {
+        protected ItemStack getRealStack() {
             return key.toStack((int) amount);
         }
 
         @Override
-        protected void setStack(ItemStack stack) {
+        protected void setRealStack(ItemStack stack) {
             key = ItemVariant.of(stack);
             amount = stack.getCount();
             notifyListeners();

--- a/src/main/java/aztech/modern_industrialization/inventory/HackySlot.java
+++ b/src/main/java/aztech/modern_industrialization/inventory/HackySlot.java
@@ -40,18 +40,18 @@ public abstract class HackySlot extends Slot {
         super(new UnsupportedOperationInventory(), 0, x, y);
     }
 
-    protected abstract ItemStack getStack();
+    protected abstract ItemStack getRealStack();
 
-    protected abstract void setStack(ItemStack stack);
+    protected abstract void setRealStack(ItemStack stack);
 
     @Override
     public final ItemStack getItem() {
-        return cachedReturnedStack = getStack();
+        return cachedReturnedStack = getRealStack();
     }
 
     @Override
     public final void set(ItemStack stack) {
-        setStack(stack);
+        setRealStack(stack);
         cachedReturnedStack = stack;
     }
 
@@ -69,7 +69,7 @@ public abstract class HackySlot extends Slot {
 
     @Override
     public final ItemStack remove(int amount) {
-        var stack = getStack().copy();
+        var stack = getRealStack().copy();
         var ret = stack.split(amount);
         set(stack);
         cachedReturnedStack = null;

--- a/src/main/java/aztech/modern_industrialization/machines/guicomponents/SlotPanel.java
+++ b/src/main/java/aztech/modern_industrialization/machines/guicomponents/SlotPanel.java
@@ -74,12 +74,12 @@ public class SlotPanel {
             int slotIndex = slotTypes.size();
             slotFactories.add(facade -> facade.addSlotToMenu(new HackySlot(getSlotX(machine.guiParams), getSlotY(slotIndex)) {
                 @Override
-                protected ItemStack getStack() {
+                protected ItemStack getRealStack() {
                     return getStack.get();
                 }
 
                 @Override
-                protected void setStack(ItemStack stack) {
+                protected void setRealStack(ItemStack stack) {
                     setStack.accept(machine, stack);
                 }
 


### PR DESCRIPTION
Identical to #567 but on master instead. Closes #520.