### PR TITLE
Remove architectury override

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,8 +181,6 @@ dependencies {
     }
 
     if (project.runtime_itemlist_mod == "rei") {
-        // Manually override architectury TODO remove once REI's dependency is fixed
-        modRuntimeOnly "dev.architectury:architectury-fabric:6.2.43"
         modImplementation("me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}") {
             exclude(group: "net.fabricmc.fabric-api")
         }


### PR DESCRIPTION
Removing the architectury dependency override as per the TODO comment. REI's dependency appears to be fixed; can build and run the client just fine with `runtime_itemlist_mod=rei`, as does the autotest server.