### PR TITLE
Fix multiblock generators voiding energy when outputting to more than 1 energy hatch

### DIFF
--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/GeneratorMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/GeneratorMultiblockBlockEntity.java
@@ -133,14 +133,15 @@ public class GeneratorMultiblockBlockEntity extends MultiblockMachineBlockEntity
 
     public long insertEnergy(long value, Simulation simulation) {
         long rem = value;
-        long inserted = 0;
+        long allInserted = 0;
         for (EnergyComponent e : energyOutputs) {
             if (rem > 0) {
-                inserted += e.insertEu(rem, simulation);
-                rem -= inserted;
+                long outputInserted = e.insertEu(rem, simulation);
+                allInserted += outputInserted;
+                rem -= outputInserted;
             }
         }
-        return inserted;
+        return allInserted;
     }
 
     protected final void link() {


### PR DESCRIPTION
This bug doesn't happen in vanilla MI because all multiblocks can only have 1 energy output hatch. You can tell this is an obvious bug just by looking at the code (that's how I found it).

To replicate use following kubejs:
```js
MIMachineEvents.registerMachines(event => {
    const pyrolyseHatch = event.hatchOf("item_input", "item_output", "fluid_input", "fluid_output", "energy_input", "energy_output");
    const heatproofMember = event.memberOfBlock("modern_industrialization:heatproof_machine_casing");
    const cupronickelCoilMember = event.memberOfBlock("modern_industrialization:cupronickel_coil");
    const pyrolyseShape = event.layeredShape("heatproof_machine_casing", [
        [ "HHH", "HHH", "HHH" ],
        [ "CCC", "C C", "CCC" ],
        [ "CCC", "C C", "CCC" ],
        [ "HHH", "H#H", "HHH" ],
    ])
        .key("H", heatproofMember, pyrolyseHatch)
        .key("C", cupronickelCoilMember, event.noHatch())
        .build();
    const largeSolidDieselGeneratorShape = pyrolyseShape //... Define your shape here as for any multiblock

    event.simpleGeneratorMultiBlock(
        "Large Solid Diesel Generator", // The english name
        "large_solid_diesel_generator", // The internal name
        largeSolidDieselGeneratorShape, // The multiblock shape
        1000000, // Maximum energy generation rate (eu/tick)
        builder => { // The builder (same as for a single block generator)
            builder.furnaceFuels().fluid("modern_industrialization:synthetic_oil", 1000);
        },
            // --- Standard model configuration --- //
        "heatproof_machine_casing", // casing
        "diesel_generator", // model folder
        true, false, false // front overlay?, top overlay?, side overlay?
    );
});
```

and the following setup (hatches need to be MV):
![2024-02-13_21 52 32](https://github.com/AztechMC/Modern-Industrialization/assets/56641258/583de620-0a08-4296-aa63-dd19d3af026c)

Previously it outputted ~0.7M EU per synthetic oil bucket, now it's ~1M EU (I'm surprised that's not less than or equal but around 1M)