### PR TITLE
Add KubeJS API for casings to easily imitate blocks

### DIFF
--- a/docs/ADDING_MACHINES.md
+++ b/docs/ADDING_MACHINES.md
@@ -316,14 +316,22 @@ Methods that config exposes:
 
 ## Adding new casing types
 See [MACHINE_MODELS.md](MACHINE_MODELS.md) for an explanation of machine models and what casings are.
-You can add new casings using the `register` function in the `MIMachineEvents.registerCasings` event.
+You can add new casings using the `MIMachineEvents.registerCasings` event.
+- Use the `register` function if you will also be adding a JSON model for the casing.
+- Use the `registerBlockImitation` function to add a casing that will imitate another block.
 
-Remember that the top, side and bottom textures of a casing must be `modern_industrialization:textures/block/casings/<casing name>/{top,side,bottom}.png`.
+If you use `register` and want a texture-based casing model,
+remember that the top, side and bottom textures of a casing must be `modern_industrialization:textures/block/casings/<casing name>/{top,side,bottom}.png`.
 
-For example, to register two new casings:
+For example:
 ```js
 MIMachineEvents.registerCasings(event => {
+    // Register two casings.
+    // This doesn't register any model! Either add models or add the top/side/bottom textures.
     event.register("my_fancy_casing", "my_other_casing");
+
+    // This registers a new casing with the same model as a diamond block!
+    event.registerBlockImitation("my_diamond_casing", "minecraft:diamond_block");
 })
 ```
 

--- a/src/client/java/aztech/modern_industrialization/datagen/model/MachineCasingsProvider.java
+++ b/src/client/java/aztech/modern_industrialization/datagen/model/MachineCasingsProvider.java
@@ -37,8 +37,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.data.CachedOutput;
 import net.minecraft.data.DataProvider;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 
@@ -91,6 +93,10 @@ public class MachineCasingsProvider implements DataProvider {
         imitateBlock.accept(MachineCasings.SOLID_TITANIUM, MIMaterials.TITANIUM.getPart(MIParts.MACHINE_CASING_SPECIAL).asBlock());
         imitateBlock.accept(MachineCasings.NUCLEAR, MIMaterials.NUCLEAR_ALLOY.getPart(MIParts.MACHINE_CASING_SPECIAL).asBlock());
         imitateBlock.accept(MachineCasings.PLASMA_HANDLING_IRIDIUM, MIMaterials.IRIDIUM.getPart(MIParts.MACHINE_CASING_SPECIAL).asBlock());
+
+        for (var entry : MachineCasingImitations.imitationsToGenerate.entrySet()) {
+            imitateBlock.accept(entry.getKey(), BuiltInRegistries.BLOCK.getOrThrow(ResourceKey.create(Registries.BLOCK, entry.getValue())));
+        }
     }
 
     @Override

--- a/src/main/java/aztech/modern_industrialization/datagen/model/MachineCasingImitations.java
+++ b/src/main/java/aztech/modern_industrialization/datagen/model/MachineCasingImitations.java
@@ -21,31 +21,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package aztech.modern_industrialization.compat.kubejs.machine;
+package aztech.modern_industrialization.datagen.model;
 
-import aztech.modern_industrialization.datagen.model.MachineCasingImitations;
-import aztech.modern_industrialization.machines.models.MachineCasings;
-import dev.latvian.mods.kubejs.event.EventJS;
-import java.util.Objects;
+import aztech.modern_industrialization.machines.models.MachineCasing;
+import java.util.HashMap;
+import java.util.Map;
 import net.minecraft.resources.ResourceLocation;
 
-public class RegisterCasingsEventJS extends EventJS {
-    public void register(String... names) {
-        for (var name : names) {
-            if (name.contains(":")) {
-                throw new IllegalArgumentException("Casing name cannot contain ':'.");
-            }
-
-            MachineCasings.create(name);
-        }
-    }
-
-    public void registerBlockImitation(String name, ResourceLocation block) {
-        Objects.requireNonNull(block, "block may not be null");
-        if (name.contains(":")) {
-            throw new IllegalArgumentException("Casing name cannot contain ':'.");
-        }
-
-        MachineCasingImitations.imitationsToGenerate.put(MachineCasings.create(name), block);
-    }
+public class MachineCasingImitations {
+    public static final Map<MachineCasing, ResourceLocation> imitationsToGenerate = new HashMap<>();
 }


### PR DESCRIPTION
Fixes #689 by introducing the following new syntax for machine casings that imitate an existing block:
```js
MIMachineEvents.registerCasings(e => {
    e.registerBlockImitation('netherrack', 'modern_industrialization:netherrack_machine_casing');
})
```

`e.register('netherrack')` only registers the casing, but since we do not automatically generate top/side/bottom copies of the texture anymore for casing parts it leads to a missing model. Either copy the textures manually, add a casing JSON manually, or use `registerBlockImitation`.