### PR TITLE
Add machine casing voltage tooltip

### DIFF
--- a/src/generated/resources/assets/modern_industrialization/lang/en_us.json
+++ b/src/generated/resources/assets/modern_industrialization/lang/en_us.json
@@ -1600,6 +1600,7 @@
   "text.modern_industrialization.LockingModeOff": "Lock editing disabled",
   "text.modern_industrialization.LockingModeOn": "Lock editing enabled",
   "text.modern_industrialization.LubricantTooltip": "Right-Click on Electric Machine : consume %s mb for 1 efficiency tick",
+  "text.modern_industrialization.MachineCasingVoltage": "Allows machines to accept %s power",
   "text.modern_industrialization.MachineUpgrade": "Electric Machine Upgrade : Max Overclock +%s",
   "text.modern_industrialization.MachineUpgradeStack": "Total Stack Upgrade +%s",
   "text.modern_industrialization.MaxEuProduction": "Can produce up to %s",

--- a/src/generated/resources/assets/modern_industrialization/lang/untranslated/ko_kr.json
+++ b/src/generated/resources/assets/modern_industrialization/lang/untranslated/ko_kr.json
@@ -1819,6 +1819,7 @@
   "text.modern_industrialization.LockingModeOff": "[UNTRANSLATED] Lock editing disabled",
   "text.modern_industrialization.LockingModeOn": "[UNTRANSLATED] Lock editing enabled",
   "text.modern_industrialization.LubricantTooltip": "[UNTRANSLATED] Right-Click on Electric Machine : consume %s mb for 1 efficiency tick",
+  "text.modern_industrialization.MachineCasingVoltage": "[UNTRANSLATED] Allows machines to accept %s power",
   "text.modern_industrialization.MachineUpgrade": "[UNTRANSLATED] Electric Machine Upgrade : Max Overclock +%s",
   "text.modern_industrialization.MachineUpgradeStack": "[UNTRANSLATED] Total Stack Upgrade +%s",
   "text.modern_industrialization.MaxEuProduction": "[UNTRANSLATED] Can produce up to %s",

--- a/src/generated/resources/assets/modern_industrialization/lang/untranslated/pt_br.json
+++ b/src/generated/resources/assets/modern_industrialization/lang/untranslated/pt_br.json
@@ -1612,6 +1612,7 @@
   "text.modern_industrialization.LockingModeOff": "Edição de Trancas desativada",
   "text.modern_industrialization.LockingModeOn": "Edição de Trancas ativada",
   "text.modern_industrialization.LubricantTooltip": "Botão-Direito em Máquina Elétrica : consome %s mb por 1 tick de eficiência",
+  "text.modern_industrialization.MachineCasingVoltage": "[UNTRANSLATED] Allows machines to accept %s power",
   "text.modern_industrialization.MachineUpgrade": "Melhoria de Máquina Elétrica : Overclock Máx. de +%s",
   "text.modern_industrialization.MachineUpgradeStack": "[UNTRANSLATED] Total Stack Upgrade +%s",
   "text.modern_industrialization.MaxEuProduction": "Pode produzir até %s",

--- a/src/generated/resources/assets/modern_industrialization/lang/untranslated/ru_ru.json
+++ b/src/generated/resources/assets/modern_industrialization/lang/untranslated/ru_ru.json
@@ -1612,6 +1612,7 @@
   "text.modern_industrialization.LockingModeOff": "Блокировка правки отключена",
   "text.modern_industrialization.LockingModeOn": "Блокировка правки включена",
   "text.modern_industrialization.LubricantTooltip": "ПКМ по электрическому станку: потребит %s мв за 1 такт эффективности",
+  "text.modern_industrialization.MachineCasingVoltage": "[UNTRANSLATED] Allows machines to accept %s power",
   "text.modern_industrialization.MachineUpgrade": "Модернизация электрического станка: Максимальный разгон +%s",
   "text.modern_industrialization.MachineUpgradeStack": "[UNTRANSLATED] Total Stack Upgrade +%s",
   "text.modern_industrialization.MaxEuProduction": "Может производить до %s",

--- a/src/generated/resources/assets/modern_industrialization/lang/untranslated/zh_cn.json
+++ b/src/generated/resources/assets/modern_industrialization/lang/untranslated/zh_cn.json
@@ -1903,6 +1903,7 @@
   "text.modern_industrialization.LockingModeOff": "已禁用锁定编辑",
   "text.modern_industrialization.LockingModeOn": "已启用锁定编辑",
   "text.modern_industrialization.LubricantTooltip": "在电力机器上右键：消耗 %smB 增加一个效率计数器",
+  "text.modern_industrialization.MachineCasingVoltage": "[UNTRANSLATED] Allows machines to accept %s power",
   "text.modern_industrialization.MachineUpgrade": "电力机器升级：最大超频 +%s",
   "text.modern_industrialization.MachineUpgradeStack": "整堆叠升级 +%s",
   "text.modern_industrialization.MaxEuProduction": "最多可供应：%s",

--- a/src/generated/resources/assets/modern_industrialization/lang/untranslated/zh_tw.json
+++ b/src/generated/resources/assets/modern_industrialization/lang/untranslated/zh_tw.json
@@ -1813,6 +1813,7 @@
   "text.modern_industrialization.LockingModeOff": "[UNTRANSLATED] Lock editing disabled",
   "text.modern_industrialization.LockingModeOn": "[UNTRANSLATED] Lock editing enabled",
   "text.modern_industrialization.LubricantTooltip": "[UNTRANSLATED] Right-Click on Electric Machine : consume %s mb for 1 efficiency tick",
+  "text.modern_industrialization.MachineCasingVoltage": "[UNTRANSLATED] Allows machines to accept %s power",
   "text.modern_industrialization.MachineUpgrade": "[UNTRANSLATED] Electric Machine Upgrade : Max Overclock +%s",
   "text.modern_industrialization.MachineUpgradeStack": "[UNTRANSLATED] Total Stack Upgrade +%s",
   "text.modern_industrialization.MaxEuProduction": "[UNTRANSLATED] Can produce up to %s",

--- a/src/main/java/aztech/modern_industrialization/MIText.java
+++ b/src/main/java/aztech/modern_industrialization/MIText.java
@@ -145,6 +145,7 @@ public enum MIText {
     LockingModeOff("Lock editing disabled"),
     LockingModeOn("Lock editing enabled"),
     LubricantTooltip("Right-Click on Electric Machine : consume %s mb for 1 efficiency tick"),
+    MachineCasingVoltage("Allows machines to accept %s power"),
     MachineUpgrade("Electric Machine Upgrade : Max Overclock +%s"),
     MachineUpgradeStack("Total Stack Upgrade +%s"),
     MaxEuProduction("Can produce up to %s"),
@@ -248,8 +249,7 @@ public enum MIText {
     Unlocked("Unlocked"),
     UseItemToChange("Right-click to change."),
     WaterPercent("Water: %s %%"),
-    Whitelist("Whitelist mode enabled"),
-    MachineCasingVoltage("Allows machines to accept %s power");
+    Whitelist("Whitelist mode enabled");
 
     private final String root;
     private final String englishText;

--- a/src/main/java/aztech/modern_industrialization/MIText.java
+++ b/src/main/java/aztech/modern_industrialization/MIText.java
@@ -248,7 +248,8 @@ public enum MIText {
     Unlocked("Unlocked"),
     UseItemToChange("Right-click to change."),
     WaterPercent("Water: %s %%"),
-    Whitelist("Whitelist mode enabled");
+    Whitelist("Whitelist mode enabled"),
+    MachineCasingVoltage("Allows machines to accept %s power");
 
     private final String root;
     private final String englishText;

--- a/src/main/java/aztech/modern_industrialization/MITooltips.java
+++ b/src/main/java/aztech/modern_industrialization/MITooltips.java
@@ -32,6 +32,7 @@ import aztech.modern_industrialization.items.PortableStorageUnit;
 import aztech.modern_industrialization.items.RedstoneControlModuleItem;
 import aztech.modern_industrialization.machines.MachineBlock;
 import aztech.modern_industrialization.machines.blockentities.multiblocks.ElectricBlastFurnaceBlockEntity;
+import aztech.modern_industrialization.machines.components.CasingComponent;
 import aztech.modern_industrialization.machines.components.LubricantHelper;
 import aztech.modern_industrialization.machines.components.UpgradeComponent;
 import aztech.modern_industrialization.nuclear.NuclearAbsorbable;
@@ -389,13 +390,10 @@ public class MITooltips {
 
     public static final TooltipAttachment MACHINE_CASING_VOLTAGE = TooltipAttachment.of(
             (itemStack, item) -> {
-                var itemKey = BuiltInRegistries.ITEM.getKey(item);
-                for (var tier : CableTier.allTiers()) {
-                    if (tier.itemKey != null && tier.itemKey.equals(itemKey)) {
-                        return Optional.of(new Line(MIText.MachineCasingVoltage).arg(Component.translatable(tier.shortEnglishKey())).build());
-                    }
-                }
-                return Optional.empty();
+                CableTier tier = CasingComponent.getCasingTier(item);
+                return tier == null ?
+                        Optional.empty() :
+                        Optional.of(new Line(MIText.MachineCasingVoltage).arg(Component.translatable(tier.shortEnglishKey())).build());
             });
 
     // Long Tooltip with only text, no need of MIText

--- a/src/main/java/aztech/modern_industrialization/MITooltips.java
+++ b/src/main/java/aztech/modern_industrialization/MITooltips.java
@@ -391,9 +391,8 @@ public class MITooltips {
     public static final TooltipAttachment MACHINE_CASING_VOLTAGE = TooltipAttachment.of(
             (itemStack, item) -> {
                 CableTier tier = CasingComponent.getCasingTier(item);
-                return tier == null ?
-                        Optional.empty() :
-                        Optional.of(new Line(MIText.MachineCasingVoltage).arg(Component.translatable(tier.shortEnglishKey())).build());
+                return tier == null ? Optional.empty()
+                        : Optional.of(new Line(MIText.MachineCasingVoltage).arg(Component.translatable(tier.shortEnglishKey())).build());
             });
 
     // Long Tooltip with only text, no need of MIText

--- a/src/main/java/aztech/modern_industrialization/MITooltips.java
+++ b/src/main/java/aztech/modern_industrialization/MITooltips.java
@@ -24,6 +24,7 @@
 package aztech.modern_industrialization;
 
 import aztech.modern_industrialization.api.datamaps.MIDataMaps;
+import aztech.modern_industrialization.api.energy.CableTier;
 import aztech.modern_industrialization.api.energy.EnergyApi;
 import aztech.modern_industrialization.blocks.OreBlock;
 import aztech.modern_industrialization.definition.FluidLike;
@@ -385,6 +386,17 @@ public class MITooltips {
             MIText.ConfigCardHelpItems4,
             MIText.ConfigCardHelpItems5,
             MIText.ConfigCardHelpClear);
+
+    public static final TooltipAttachment MACHINE_CASING_VOLTAGE = TooltipAttachment.of(
+            (itemStack, item) -> {
+                var itemKey = BuiltInRegistries.ITEM.getKey(item);
+                for (var tier : CableTier.allTiers()) {
+                    if (tier.itemKey != null && tier.itemKey.equals(itemKey)) {
+                        return Optional.of(new Line(MIText.MachineCasingVoltage).arg(Component.translatable(tier.shortEnglishKey())).build());
+                    }
+                }
+                return Optional.empty();
+            });
 
     // Long Tooltip with only text, no need of MIText
 


### PR DESCRIPTION
A couple things I should mention:

I wasn't able to get the datagen to run properly, so I figured that could be run at a later time before a release is published.

Also, the code in the tooltip is the exact same as the code in CasingComponent#getCasingTier, but I wasn't sure if I should reference that since its a method made for the component. It may be worthwhile moving this getCasingTier method elsewhere and using that here (or anywhere else that may need to reference cable tier casings). 