### PR TITLE
Avoid leaking player connection in MIKeyMap

### DIFF
--- a/src/main/java/aztech/modern_industrialization/items/armor/MIKeyMap.java
+++ b/src/main/java/aztech/modern_industrialization/items/armor/MIKeyMap.java
@@ -23,12 +23,13 @@
  */
 package aztech.modern_industrialization.items.armor;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.WeakHashMap;
+
 import net.minecraft.world.entity.player.Player;
 
 public class MIKeyMap {
-    private static final Map<Player, Boolean> HOLDING_UP = new HashMap<>();
+    private static final Map<Player, Boolean> HOLDING_UP = new WeakHashMap<>();
 
     static boolean isHoldingUp(Player player) {
         return HOLDING_UP.getOrDefault(player, false);

--- a/src/main/java/aztech/modern_industrialization/items/armor/MIKeyMap.java
+++ b/src/main/java/aztech/modern_industrialization/items/armor/MIKeyMap.java
@@ -25,7 +25,6 @@ package aztech.modern_industrialization.items.armor;
 
 import java.util.Map;
 import java.util.WeakHashMap;
-
 import net.minecraft.world.entity.player.Player;
 
 public class MIKeyMap {


### PR DESCRIPTION
This memory leak was identified through a heap dump on a ForgeCraft 1.21 client - it causes the previous client level/connection/player to be retained when rejoining a server multiple times. Making the map weak will resolve this, and should not have observable side effects since if the player was garbage collected, no one would be querying their status in the map anyway.