### PR TITLE
Fix machine process conditions

### DIFF
--- a/src/main/java/aztech/modern_industrialization/machines/recipe/MachineRecipe.java
+++ b/src/main/java/aztech/modern_industrialization/machines/recipe/MachineRecipe.java
@@ -67,7 +67,7 @@ public class MachineRecipe implements Recipe<RecipeInput> {
                                 MIExtraCodecs.maybeList(FluidInput.CODEC, "fluid_inputs").forGetter(recipe -> recipe.fluidInputs),
                                 MIExtraCodecs.maybeList(ItemOutput.CODEC, "item_outputs").forGetter(recipe -> recipe.itemOutputs),
                                 MIExtraCodecs.maybeList(FluidOutput.CODEC, "fluid_outputs").forGetter(recipe -> recipe.fluidOutputs),
-                                MIExtraCodecs.maybeList(MachineProcessCondition.CODEC, "conditions").forGetter(recipe -> recipe.conditions))
+                                MIExtraCodecs.maybeList(MachineProcessCondition.CODEC, "process_conditions").forGetter(recipe -> recipe.conditions))
                         .apply(g, (eu, duration, itemInputs, fluidInputs, itemOutputs, fluidOutputs, conditions) -> {
                             var ret = new MachineRecipe(type);
                             ret.eu = eu;

--- a/src/main/java/aztech/modern_industrialization/machines/recipe/condition/BiomeProcessCondition.java
+++ b/src/main/java/aztech/modern_industrialization/machines/recipe/condition/BiomeProcessCondition.java
@@ -28,7 +28,9 @@ import aztech.modern_industrialization.machines.recipe.MachineRecipe;
 import com.mojang.serialization.MapCodec;
 import java.util.List;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.biome.Biome;
 
@@ -36,6 +38,10 @@ public record BiomeProcessCondition(ResourceKey<Biome> biome) implements Machine
     static final MapCodec<BiomeProcessCondition> CODEC = ResourceKey.codec(Registries.BIOME)
             .fieldOf("biome")
             .xmap(BiomeProcessCondition::new, BiomeProcessCondition::biome);
+    static final StreamCodec<RegistryFriendlyByteBuf, BiomeProcessCondition> STREAM_CODEC = StreamCodec.composite(
+            ResourceKey.streamCodec(Registries.BIOME),
+            BiomeProcessCondition::biome,
+            BiomeProcessCondition::new);
 
     @Override
     public boolean canProcessRecipe(Context context, MachineRecipe recipe) {
@@ -51,7 +57,12 @@ public record BiomeProcessCondition(ResourceKey<Biome> biome) implements Machine
     }
 
     @Override
-    public MapCodec<? extends MachineProcessCondition> codec(boolean syncToClient) {
+    public MapCodec<? extends MachineProcessCondition> codec() {
         return CODEC;
+    }
+
+    @Override
+    public StreamCodec<? super RegistryFriendlyByteBuf, ? extends MachineProcessCondition> streamCodec() {
+        return STREAM_CODEC;
     }
 }

--- a/src/main/java/aztech/modern_industrialization/machines/recipe/condition/DimensionProcessCondition.java
+++ b/src/main/java/aztech/modern_industrialization/machines/recipe/condition/DimensionProcessCondition.java
@@ -28,7 +28,9 @@ import aztech.modern_industrialization.machines.recipe.MachineRecipe;
 import com.mojang.serialization.MapCodec;
 import java.util.List;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.Level;
 
@@ -36,6 +38,11 @@ public record DimensionProcessCondition(ResourceKey<Level> dimension) implements
     static final MapCodec<DimensionProcessCondition> CODEC = ResourceKey.codec(Registries.DIMENSION)
             .fieldOf("dimension")
             .xmap(DimensionProcessCondition::new, DimensionProcessCondition::dimension);
+
+    static final StreamCodec<RegistryFriendlyByteBuf, DimensionProcessCondition> STREAM_CODEC = StreamCodec.composite(
+            ResourceKey.streamCodec(Registries.DIMENSION),
+            DimensionProcessCondition::dimension,
+            DimensionProcessCondition::new);
 
     @Override
     public boolean canProcessRecipe(Context context, MachineRecipe recipe) {
@@ -50,7 +57,12 @@ public record DimensionProcessCondition(ResourceKey<Level> dimension) implements
     }
 
     @Override
-    public MapCodec<? extends MachineProcessCondition> codec(boolean syncToClient) {
+    public MapCodec<? extends MachineProcessCondition> codec() {
         return CODEC;
+    }
+
+    @Override
+    public StreamCodec<? super RegistryFriendlyByteBuf, ? extends MachineProcessCondition> streamCodec() {
+        return STREAM_CODEC;
     }
 }


### PR DESCRIPTION
- Change JSON key back to `process_conditions`.
- Fix KubeJS `itemIn` and `itemOut`.
- Rewrite process condition syncing to fix custom conditions.