### PR TITLE
Return default value for hit index and hit side instead of throwing

### DIFF
--- a/src/main/java/aztech/modern_industrialization/machines/MachineOverlay.java
+++ b/src/main/java/aztech/modern_industrialization/machines/MachineOverlay.java
@@ -78,7 +78,8 @@ public class MachineOverlay {
                 return i;
             }
         }
-        throw new UnsupportedOperationException("Hit shape could not be found :(");
+        // hit from really weird direction - default to center of machine
+        return 1 * 3 * 3 + 1 * 3 + 1;
     }
 
     public static Direction findHitSide(Vec3 posInBlock, Direction hitFace) {
@@ -96,7 +97,8 @@ public class MachineOverlay {
                 }
             }
         }
-        throw new RuntimeException("Unreachable!");
+        // hit from inside of machine - default to center
+        return hitFace;
     }
 
     public static Direction findHitSide(BlockHitResult bhr) {


### PR DESCRIPTION
Fixes #847

Instead of throwing, we should return a reasonable default value - in this case, use the direction hit as the face hit and not deal with the overlay. (Additionally, we should consider only querying the overlay for wrench hits instead of all hits.)