### PR TITLE
Buff machine upgrades

### DIFF
--- a/docs/ADDING_MACHINES.md
+++ b/docs/ADDING_MACHINES.md
@@ -18,15 +18,16 @@ MIMachineEvents.addEbfTiers(event => {
 ```
 
 ## Adding electric machine upgrades
-You can add electric machine upgrades using KubeJS.
-This will allow them to be used in all the electric machines to increase the maximum EU that the machine can handle.
-
-Example:
-```js
-MIMachineEvents.registerUpgrades(event => {
-  // id of the upgrade item, number of added EU per upgrade
-  event.register("minecraft:diamond", 42);
-});
+You can add electric machine upgrades using the `modern_industrialization:machine_upgrades` item data map.
+For example, in `data/modern_industrialization/data_maps/item/machine_upgrades.json`:
+```json
+{
+  "values": {
+    "minecraft:diamond": {
+      "extraMaxEu": 42
+    }
+  }
+}
 ```
 
 ## Registering a recipe type

--- a/src/generated/resources/data/modern_industrialization/advancement/advanced_upgrade.json
+++ b/src/generated/resources/data/modern_industrialization/advancement/advanced_upgrade.json
@@ -1,5 +1,5 @@
 {
-  "parent": "modern_industrialization:chemical_reactor",
+  "parent": "modern_industrialization:basic_upgrade",
   "criteria": {
     "checkInv": {
       "conditions": {

--- a/src/generated/resources/data/modern_industrialization/advancement/advanced_upgrade.json
+++ b/src/generated/resources/data/modern_industrialization/advancement/advanced_upgrade.json
@@ -1,5 +1,5 @@
 {
-  "parent": "modern_industrialization:basic_upgrade",
+  "parent": "modern_industrialization:chemical_reactor",
   "criteria": {
     "checkInv": {
       "conditions": {

--- a/src/generated/resources/data/modern_industrialization/advancement/basic_upgrade.json
+++ b/src/generated/resources/data/modern_industrialization/advancement/basic_upgrade.json
@@ -1,5 +1,5 @@
 {
-  "parent": "modern_industrialization:chemical_reactor",
+  "parent": "modern_industrialization:assembler",
   "criteria": {
     "checkInv": {
       "conditions": {

--- a/src/generated/resources/data/modern_industrialization/advancement/basic_upgrade.json
+++ b/src/generated/resources/data/modern_industrialization/advancement/basic_upgrade.json
@@ -1,5 +1,5 @@
 {
-  "parent": "modern_industrialization:assembler",
+  "parent": "modern_industrialization:chemical_reactor",
   "criteria": {
     "checkInv": {
       "conditions": {

--- a/src/generated/resources/data/modern_industrialization/data_maps/item/machine_upgrades.json
+++ b/src/generated/resources/data/modern_industrialization/data_maps/item/machine_upgrades.json
@@ -1,0 +1,19 @@
+{
+  "values": {
+    "modern_industrialization:advanced_upgrade": {
+      "extraMaxEu": 8
+    },
+    "modern_industrialization:basic_upgrade": {
+      "extraMaxEu": 2
+    },
+    "modern_industrialization:highly_advanced_upgrade": {
+      "extraMaxEu": 128
+    },
+    "modern_industrialization:quantum_upgrade": {
+      "extraMaxEu": 999999999
+    },
+    "modern_industrialization:turbo_upgrade": {
+      "extraMaxEu": 32
+    }
+  }
+}

--- a/src/generated/resources/data/modern_industrialization/data_maps/item/machine_upgrades.json
+++ b/src/generated/resources/data/modern_industrialization/data_maps/item/machine_upgrades.json
@@ -1,19 +1,19 @@
 {
   "values": {
     "modern_industrialization:advanced_upgrade": {
-      "extraMaxEu": 8
+      "extraMaxEu": 16
     },
     "modern_industrialization:basic_upgrade": {
       "extraMaxEu": 2
     },
     "modern_industrialization:highly_advanced_upgrade": {
-      "extraMaxEu": 128
+      "extraMaxEu": 1024
     },
     "modern_industrialization:quantum_upgrade": {
       "extraMaxEu": 999999999
     },
     "modern_industrialization:turbo_upgrade": {
-      "extraMaxEu": 32
+      "extraMaxEu": 128
     }
   }
 }

--- a/src/generated/resources/data/modern_industrialization/data_maps/item/machine_upgrades.json
+++ b/src/generated/resources/data/modern_industrialization/data_maps/item/machine_upgrades.json
@@ -7,13 +7,13 @@
       "extraMaxEu": 2
     },
     "modern_industrialization:highly_advanced_upgrade": {
-      "extraMaxEu": 1024
+      "extraMaxEu": 512
     },
     "modern_industrialization:quantum_upgrade": {
       "extraMaxEu": 999999999
     },
     "modern_industrialization:turbo_upgrade": {
-      "extraMaxEu": 128
+      "extraMaxEu": 64
     }
   }
 }

--- a/src/main/java/aztech/modern_industrialization/MI.java
+++ b/src/main/java/aztech/modern_industrialization/MI.java
@@ -199,6 +199,7 @@ public class MI {
         modBus.addListener(RegisterDataMapTypesEvent.class, event -> {
             event.register(MIDataMaps.FLUID_FUELS);
             event.register(MIDataMaps.ITEM_PIPE_UPGRADES);
+            event.register(MIDataMaps.MACHINE_UPGRADES);
         });
 
         if (MIConfig.loadAe2Compat()) {

--- a/src/main/java/aztech/modern_industrialization/api/datamaps/MIDataMaps.java
+++ b/src/main/java/aztech/modern_industrialization/api/datamaps/MIDataMaps.java
@@ -45,6 +45,15 @@ public final class MIDataMaps {
             .synced(ItemPipeUpgrade.CODEC, true)
             .build();
 
+    /**
+     * Items that can be added to electric machines, to increase the maximum EU/t they can support.
+     */
+    public static final DataMapType<Item, MachineUpgrade> MACHINE_UPGRADES = DataMapType
+            .builder(
+                    MI.id("machine_upgrades"), Registries.ITEM, MachineUpgrade.CODEC)
+            .synced(MachineUpgrade.CODEC, true)
+            .build();
+
     private MIDataMaps() {
     }
 }

--- a/src/main/java/aztech/modern_industrialization/api/datamaps/MachineUpgrade.java
+++ b/src/main/java/aztech/modern_industrialization/api/datamaps/MachineUpgrade.java
@@ -21,14 +21,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package aztech.modern_industrialization.compat.kubejs.machine;
+package aztech.modern_industrialization.api.datamaps;
 
-import aztech.modern_industrialization.machines.components.UpgradeComponent;
-import dev.latvian.mods.kubejs.event.KubeEvent;
-import net.minecraft.resources.ResourceLocation;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.util.ExtraCodecs;
 
-public class RegisterUpgradesEventJS implements KubeEvent {
-    public static void register(ResourceLocation itemId, long extraEu) {
-        UpgradeComponent.registerUpgrade(itemId, extraEu);
-    }
+public record MachineUpgrade(int extraMaxEu) {
+    public static final Codec<MachineUpgrade> CODEC = RecordCodecBuilder.create(
+            instance -> instance
+                    .group(ExtraCodecs.POSITIVE_INT.fieldOf("extraMaxEu").forGetter(MachineUpgrade::extraMaxEu))
+                    .apply(instance, MachineUpgrade::new));
 }

--- a/src/main/java/aztech/modern_industrialization/compat/kubejs/LoadedKubeJSProxy.java
+++ b/src/main/java/aztech/modern_industrialization/compat/kubejs/LoadedKubeJSProxy.java
@@ -70,11 +70,6 @@ public class LoadedKubeJSProxy extends KubeJSProxy {
     }
 
     @Override
-    public void fireRegisterUpgradesEvent() {
-        MIMachineKubeJSEvents.REGISTER_UPGRADES.post(new RegisterUpgradesEventJS());
-    }
-
-    @Override
     public void fireAddMultiblockSlotsEvent(String category, SlotPositions.Builder itemInputs, SlotPositions.Builder itemOutputs,
             SlotPositions.Builder fluidInputs, SlotPositions.Builder fluidOutputs) {
         var event = new AddMultiblockSlotsEventJS(itemInputs, itemOutputs, fluidInputs, fluidOutputs);

--- a/src/main/java/aztech/modern_industrialization/compat/kubejs/machine/MIMachineKubeJSEvents.java
+++ b/src/main/java/aztech/modern_industrialization/compat/kubejs/machine/MIMachineKubeJSEvents.java
@@ -34,7 +34,6 @@ public interface MIMachineKubeJSEvents {
     EventHandler REGISTER_RECIPE_TYPES = EVENT_GROUP.startup("registerRecipeTypes", () -> RegisterRecipeTypesEventJS.class);
     EventHandler REGISTER_CASINGS = EVENT_GROUP.startup("registerCasings", () -> RegisterCasingsEventJS.class);
     EventHandler REGISTER_MACHINES = EVENT_GROUP.startup("registerMachines", () -> RegisterMachinesEventJS.class);
-    EventHandler REGISTER_UPGRADES = EVENT_GROUP.startup("registerUpgrades", () -> RegisterUpgradesEventJS.class);
     TargetedEventHandler<String> ADD_MULTIBLOCK_SLOTS = EVENT_GROUP.startup("addMultiblockSlots", () -> AddMultiblockSlotsEventJS.class)
             .requiredTarget(EventTargetType.STRING);
     EventHandler ADD_EBF_TIERS = EVENT_GROUP.startup("addEbfTiers", () -> AddEbfTiersEventJS.class);

--- a/src/main/java/aztech/modern_industrialization/datagen/advancement/MIAdvancementsProvider.java
+++ b/src/main/java/aztech/modern_industrialization/datagen/advancement/MIAdvancementsProvider.java
@@ -212,8 +212,8 @@ public record MIAdvancementsProvider(TranslationProvider translations) implement
         var quantumCircuit = createBasic(consumer, "quantum_circuit", mixedIngotIridium, AdvancementType.GOAL, "Mobius Strip Eigenvalues", "Craft a Quantum Circuit", existingFileHelper);
         var fusionReactor = createBasic(consumer, "fusion_reactor", quantumCircuit, AdvancementType.CHALLENGE, "Enslaved Star Core", "Craft a Fusion Reactor to produce insane amount of energy", existingFileHelper);
         var plasmaTurbine = createBasic(consumer, "plasma_turbine", fusionReactor, "Better than Nuclear Fission", "Craft a Plasma Turbine to transform Helium Plasma into energy", existingFileHelper);
-        var basicUpgrade = createBasic(consumer, "basic_upgrade", assembler, AdvancementType.GOAL, "Machine Speedup", "Craft a Basic Upgrade to increase the maximum speed of an electric recipe", existingFileHelper);
-        var advancedUpgrade = createBasic(consumer, "advanced_upgrade", chemicalReactor, "Machine Speedup-Speedup", "Craft a Advanced Upgrade", existingFileHelper);
+        var basicUpgrade = createBasic(consumer, "basic_upgrade", chemicalReactor, AdvancementType.GOAL, "Machine Speedup", "Craft a Basic Upgrade to increase the maximum speed of an electric recipe", existingFileHelper);
+        var advancedUpgrade = createBasic(consumer, "advanced_upgrade", basicUpgrade, "Machine Speedup-Speedup", "Craft a Advanced Upgrade", existingFileHelper);
         var turboUpgrade = createBasic(consumer, "turbo_upgrade", digitalCircuit, "Gotta go Fast", "Craft a Turbo Upgrade", existingFileHelper);
         var highlyAdvancedUpgrade = createBasic(consumer, "highly_advanced_upgrade", processingUnit, "I'm speed", "Craft an Highly Advanced Upgrade", existingFileHelper);
         var quantumUpgrade = createBasic(consumer, "quantum_upgrade", quantumCircuit, AdvancementType.GOAL, "Time Dilation", "Craft a Quantum Upgrade to unlock unlimited recipe speed", existingFileHelper);

--- a/src/main/java/aztech/modern_industrialization/datagen/advancement/MIAdvancementsProvider.java
+++ b/src/main/java/aztech/modern_industrialization/datagen/advancement/MIAdvancementsProvider.java
@@ -212,8 +212,8 @@ public record MIAdvancementsProvider(TranslationProvider translations) implement
         var quantumCircuit = createBasic(consumer, "quantum_circuit", mixedIngotIridium, AdvancementType.GOAL, "Mobius Strip Eigenvalues", "Craft a Quantum Circuit", existingFileHelper);
         var fusionReactor = createBasic(consumer, "fusion_reactor", quantumCircuit, AdvancementType.CHALLENGE, "Enslaved Star Core", "Craft a Fusion Reactor to produce insane amount of energy", existingFileHelper);
         var plasmaTurbine = createBasic(consumer, "plasma_turbine", fusionReactor, "Better than Nuclear Fission", "Craft a Plasma Turbine to transform Helium Plasma into energy", existingFileHelper);
-        var basicUpgrade = createBasic(consumer, "basic_upgrade", chemicalReactor, AdvancementType.GOAL, "Machine Speedup", "Craft a Basic Upgrade to increase the maximum speed of an electric recipe", existingFileHelper);
-        var advancedUpgrade = createBasic(consumer, "advanced_upgrade", basicUpgrade, "Machine Speedup-Speedup", "Craft a Advanced Upgrade", existingFileHelper);
+        var basicUpgrade = createBasic(consumer, "basic_upgrade", assembler, AdvancementType.GOAL, "Machine Speedup", "Craft a Basic Upgrade to increase the maximum speed of an electric recipe", existingFileHelper);
+        var advancedUpgrade = createBasic(consumer, "advanced_upgrade", chemicalReactor, "Machine Speedup-Speedup", "Craft a Advanced Upgrade", existingFileHelper);
         var turboUpgrade = createBasic(consumer, "turbo_upgrade", digitalCircuit, "Gotta go Fast", "Craft a Turbo Upgrade", existingFileHelper);
         var highlyAdvancedUpgrade = createBasic(consumer, "highly_advanced_upgrade", processingUnit, "I'm speed", "Craft an Highly Advanced Upgrade", existingFileHelper);
         var quantumUpgrade = createBasic(consumer, "quantum_upgrade", quantumCircuit, AdvancementType.GOAL, "Time Dilation", "Craft a Quantum Upgrade to unlock unlimited recipe speed", existingFileHelper);

--- a/src/main/java/aztech/modern_industrialization/datagen/datamap/MIDataMapProvider.java
+++ b/src/main/java/aztech/modern_industrialization/datagen/datamap/MIDataMapProvider.java
@@ -110,9 +110,9 @@ public class MIDataMapProvider extends DataMapProvider {
 
     private void gatherMachineUpgrades() {
         addMachineUpgrade(MIItem.BASIC_UPGRADE, 2);
-        addMachineUpgrade(MIItem.ADVANCED_UPGRADE, 8);
-        addMachineUpgrade(MIItem.TURBO_UPGRADE, 32);
-        addMachineUpgrade(MIItem.HIGHLY_ADVANCED_UPGRADE, 128);
+        addMachineUpgrade(MIItem.ADVANCED_UPGRADE, 16);
+        addMachineUpgrade(MIItem.TURBO_UPGRADE, 128);
+        addMachineUpgrade(MIItem.HIGHLY_ADVANCED_UPGRADE, 1024);
         addMachineUpgrade(MIItem.QUANTUM_UPGRADE, 999999999);
     }
 

--- a/src/main/java/aztech/modern_industrialization/datagen/datamap/MIDataMapProvider.java
+++ b/src/main/java/aztech/modern_industrialization/datagen/datamap/MIDataMapProvider.java
@@ -29,6 +29,7 @@ import aztech.modern_industrialization.MIItem;
 import aztech.modern_industrialization.api.datamaps.FluidFuel;
 import aztech.modern_industrialization.api.datamaps.ItemPipeUpgrade;
 import aztech.modern_industrialization.api.datamaps.MIDataMaps;
+import aztech.modern_industrialization.api.datamaps.MachineUpgrade;
 import aztech.modern_industrialization.definition.FluidDefinition;
 import aztech.modern_industrialization.definition.ItemDefinition;
 import java.util.concurrent.CompletableFuture;
@@ -51,6 +52,7 @@ public class MIDataMapProvider extends DataMapProvider {
 
         gatherFluidFuels();
         gatherItemPipeUpgrades();
+        gatherMachineUpgrades();
     }
 
     private void gatherFurnaceFuels() {
@@ -104,5 +106,17 @@ public class MIDataMapProvider extends DataMapProvider {
 
     private void addItemPipeUpgrade(ItemDefinition<?> itemDefinition, int maxExtractedItems) {
         builder(MIDataMaps.ITEM_PIPE_UPGRADES).add(itemDefinition.getId(), new ItemPipeUpgrade(maxExtractedItems), false);
+    }
+
+    private void gatherMachineUpgrades() {
+        addMachineUpgrade(MIItem.BASIC_UPGRADE, 2);
+        addMachineUpgrade(MIItem.ADVANCED_UPGRADE, 8);
+        addMachineUpgrade(MIItem.TURBO_UPGRADE, 32);
+        addMachineUpgrade(MIItem.HIGHLY_ADVANCED_UPGRADE, 128);
+        addMachineUpgrade(MIItem.QUANTUM_UPGRADE, 999999999);
+    }
+
+    private void addMachineUpgrade(ItemDefinition<?> itemDefinition, int extraMaxEu) {
+        builder(MIDataMaps.MACHINE_UPGRADES).add(itemDefinition.getId(), new MachineUpgrade(extraMaxEu), false);
     }
 }

--- a/src/main/java/aztech/modern_industrialization/datagen/datamap/MIDataMapProvider.java
+++ b/src/main/java/aztech/modern_industrialization/datagen/datamap/MIDataMapProvider.java
@@ -111,8 +111,8 @@ public class MIDataMapProvider extends DataMapProvider {
     private void gatherMachineUpgrades() {
         addMachineUpgrade(MIItem.BASIC_UPGRADE, 2);
         addMachineUpgrade(MIItem.ADVANCED_UPGRADE, 16);
-        addMachineUpgrade(MIItem.TURBO_UPGRADE, 128);
-        addMachineUpgrade(MIItem.HIGHLY_ADVANCED_UPGRADE, 1024);
+        addMachineUpgrade(MIItem.TURBO_UPGRADE, 64);
+        addMachineUpgrade(MIItem.HIGHLY_ADVANCED_UPGRADE, 512);
         addMachineUpgrade(MIItem.QUANTUM_UPGRADE, 999999999);
     }
 

--- a/src/main/java/aztech/modern_industrialization/machines/components/UpgradeComponent.java
+++ b/src/main/java/aztech/modern_industrialization/machines/components/UpgradeComponent.java
@@ -23,17 +23,12 @@
  */
 package aztech.modern_industrialization.machines.components;
 
-import aztech.modern_industrialization.MIItem;
+import aztech.modern_industrialization.api.datamaps.MIDataMaps;
 import aztech.modern_industrialization.compat.kubejs.KubeJSProxy;
 import aztech.modern_industrialization.machines.IComponent;
 import aztech.modern_industrialization.machines.MachineBlockEntity;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.ItemInteractionResult;
 import net.minecraft.world.entity.player.Player;
@@ -43,37 +38,13 @@ import net.minecraft.world.level.ItemLike;
 public class UpgradeComponent implements IComponent.ServerOnly, DropableComponent {
 
     private ItemStack itemStack = ItemStack.EMPTY;
-    private final static Map<ResourceLocation, Long> UPGRADES = new HashMap<>();
 
     public static long getExtraEu(ItemLike item) {
-        return UPGRADES.getOrDefault(BuiltInRegistries.ITEM.getKey(item.asItem()), 0L);
-    }
-
-    public static void registerUpgrade(ItemLike item, long extraEu) {
-        registerUpgrade(BuiltInRegistries.ITEM.getKey(item.asItem()), extraEu);
-    }
-
-    public static void registerUpgrade(ResourceLocation itemId, long extraEu) {
-        Objects.requireNonNull(itemId);
-
-        if (extraEu <= 0) {
-            throw new IllegalArgumentException("extraEu must be positive");
-        }
-
-        if (UPGRADES.containsKey(itemId)) {
-            throw new IllegalArgumentException("Upgrade already registered:" + itemId);
-        }
-
-        UPGRADES.put(itemId, extraEu);
+        var data = item.asItem().builtInRegistryHolder().getData(MIDataMaps.MACHINE_UPGRADES);
+        return data == null ? 0 : data.extraMaxEu();
     }
 
     static {
-        registerUpgrade(MIItem.BASIC_UPGRADE.asItem(), 2L);
-        registerUpgrade(MIItem.ADVANCED_UPGRADE.asItem(), 8L);
-        registerUpgrade(MIItem.TURBO_UPGRADE.asItem(), 32L);
-        registerUpgrade(MIItem.HIGHLY_ADVANCED_UPGRADE.asItem(), 128L);
-        registerUpgrade(MIItem.QUANTUM_UPGRADE.asItem(), 999999999L);
-
         KubeJSProxy.instance.fireRegisterUpgradesEvent();
     }
 

--- a/src/main/resources/assets/modern_industrialization/patchouli_books/book/en_us/entries/electric_age/basic_machines.json
+++ b/src/main/resources/assets/modern_industrialization/patchouli_books/book/en_us/entries/electric_age/basic_machines.json
@@ -30,18 +30,6 @@
     {
       "type": "text",
       "text": "We strongly suggest that you automate Machine Hull, Analog Circuits, Motors, Pistons, Robot Arms and Conveyor Belts using Assemblers as soon as possible, that will make crafting electric machines basically free!"
-    },
-    {
-      "type": "spotlight",
-      "title": "Redstone Control Modules",
-      "item": "modern_industrialization:redstone_control_module",
-      "text": "A Redstone Control Module can be used to control the behavior of electric machines and multiblocks with redstone signals.$(br2)Configure the module in your hand, then insert it into the machine or multiblock controller."
-    },
-    {
-      "type": "spotlight",
-      "title": "Overclock Upgrades",
-      "item": "modern_industrialization:basic_upgrade",
-      "text": "Regular electric machines have an overclock capped at 32 EU/t, and electric multiblocks have an overclock capped at 128 EU/t.$(br2)In the machine or multiblock's menu, add upgades to increase its maximum overclock! Check REI for the exact amounts."
     }
   ],
   "sortnum": 105

--- a/src/main/resources/assets/modern_industrialization/patchouli_books/book/en_us/entries/electric_age/basic_machines.json
+++ b/src/main/resources/assets/modern_industrialization/patchouli_books/book/en_us/entries/electric_age/basic_machines.json
@@ -30,6 +30,18 @@
     {
       "type": "text",
       "text": "We strongly suggest that you automate Machine Hull, Analog Circuits, Motors, Pistons, Robot Arms and Conveyor Belts using Assemblers as soon as possible, that will make crafting electric machines basically free!"
+    },
+    {
+      "type": "spotlight",
+      "title": "Redstone Control Modules",
+      "item": "modern_industrialization:redstone_control_module",
+      "text": "A Redstone Control Module can be used to control the behavior of electric machines and multiblocks with redstone signals.$(br2)Configure the module in your hand, then insert it into the machine or multiblock controller."
+    },
+    {
+      "type": "spotlight",
+      "title": "Overclock Upgrades",
+      "item": "modern_industrialization:basic_upgrade",
+      "text": "Regular electric machines have an overclock capped at 32 EU/t, and electric multiblocks have an overclock capped at 128 EU/t.$(br2)In the machine or multiblock's menu, add upgades to increase its maximum overclock! Check REI for the exact amounts."
     }
   ],
   "sortnum": 105

--- a/src/main/resources/assets/modern_industrialization/patchouli_books/book/en_us/entries/midgame/upgrades.json
+++ b/src/main/resources/assets/modern_industrialization/patchouli_books/book/en_us/entries/midgame/upgrades.json
@@ -5,6 +5,18 @@
   "pages": [
     {
       "type": "spotlight",
+      "title": "Redstone Control Modules",
+      "item": "modern_industrialization:redstone_control_module",
+      "text": "A Redstone Control Module can be used to control the behavior of electric machines and multiblocks with redstone signals.$(br2)Configure the module in your hand, then insert it into the machine or multiblock controller."
+    },
+    {
+      "type": "spotlight",
+      "title": "Overclock Upgrades",
+      "item": "modern_industrialization:basic_upgrade",
+      "text": "You know that regular electric machines have an overclock capped at 32 EU/t, and electric multiblocks have an overclock capped at 128 EU/t?$(br2)In the machine or multiblock's menu, add upgades to increase its maximum overclock! Check REI for the exact amounts."
+    },
+    {
+      "type": "spotlight",
       "title": "Machine Hull Upgrades",
       "item": "modern_industrialization:advanced_machine_hull",
       "text": "Yes you can! Right-click a machine with an Advanced Machine Hull to change it to MV tier: it will now accept MV cable connections only. The machine hull can also be set or cleared via the user interface."

--- a/src/main/resources/assets/modern_industrialization/patchouli_books/book/en_us/entries/midgame/upgrades.json
+++ b/src/main/resources/assets/modern_industrialization/patchouli_books/book/en_us/entries/midgame/upgrades.json
@@ -5,18 +5,6 @@
   "pages": [
     {
       "type": "spotlight",
-      "title": "Redstone Control Modules",
-      "item": "modern_industrialization:redstone_control_module",
-      "text": "A Redstone Control Module can be used to control the behavior of electric machines and multiblocks with redstone signals.$(br2)Configure the module in your hand, then insert it into the machine or multiblock controller."
-    },
-    {
-      "type": "spotlight",
-      "title": "Overclock Upgrades",
-      "item": "modern_industrialization:basic_upgrade",
-      "text": "You know that regular electric machines have an overclock capped at 32 EU/t, and electric multiblocks have an overclock capped at 128 EU/t?$(br2)In the machine or multiblock's menu, add upgades to increase its maximum overclock! Check REI for the exact amounts."
-    },
-    {
-      "type": "spotlight",
       "title": "Machine Hull Upgrades",
       "item": "modern_industrialization:advanced_machine_hull",
       "text": "Yes you can! Right-click a machine with an Advanced Machine Hull to change it to MV tier: it will now accept MV cable connections only. The machine hull can also be set or cleared via the user interface."

--- a/src/main/resources/data/modern_industrialization/recipe/electric_age/upgrades/basic.json
+++ b/src/main/resources/data/modern_industrialization/recipe/electric_age/upgrades/basic.json
@@ -20,11 +20,6 @@
       "amount": 1
     }
   ],
-
-  "fluid_inputs": {
-    "fluid" : "modern_industrialization:polyethylene",
-    "amount" : 500
-  },
   "item_outputs": [
     {
       "item": "modern_industrialization:basic_upgrade",

--- a/src/main/resources/data/modern_industrialization/recipe/electric_age/upgrades/basic.json
+++ b/src/main/resources/data/modern_industrialization/recipe/electric_age/upgrades/basic.json
@@ -20,6 +20,11 @@
       "amount": 1
     }
   ],
+
+  "fluid_inputs": {
+    "fluid" : "modern_industrialization:polyethylene",
+    "amount" : 500
+  },
   "item_outputs": [
     {
       "item": "modern_industrialization:basic_upgrade",


### PR DESCRIPTION
Buff machine upgrades:
- Basic Upgrade: remains at 2. Polyethylene requirement removed.
- Advanced Upgrade: 8 -> 16.
- Turbo Upgrade: 32 -> 64.
- Highly Advanced Upgrade: 128 -> 512.