### PR TITLE
Make CableTier more accessible

### DIFF
--- a/src/main/java/aztech/modern_industrialization/api/energy/CableTierHolder.java
+++ b/src/main/java/aztech/modern_industrialization/api/energy/CableTierHolder.java
@@ -1,0 +1,28 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Azercoco & Technici4n
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package aztech.modern_industrialization.api.energy;
+
+public interface CableTierHolder {
+    CableTier getCableTier();
+}

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/ElectricCraftingMachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/ElectricCraftingMachineBlockEntity.java
@@ -24,6 +24,8 @@
 package aztech.modern_industrialization.machines.blockentities;
 
 import aztech.modern_industrialization.MICapabilities;
+import aztech.modern_industrialization.api.energy.CableTier;
+import aztech.modern_industrialization.api.energy.CableTierHolder;
 import aztech.modern_industrialization.api.energy.EnergyApi;
 import aztech.modern_industrialization.api.energy.MIEnergyStorage;
 import aztech.modern_industrialization.api.machine.holder.EnergyComponentHolder;
@@ -44,7 +46,7 @@ import net.minecraft.world.ItemInteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 
-public class ElectricCraftingMachineBlockEntity extends AbstractCraftingMachineBlockEntity implements EnergyComponentHolder {
+public class ElectricCraftingMachineBlockEntity extends AbstractCraftingMachineBlockEntity implements EnergyComponentHolder, CableTierHolder {
 
     public ElectricCraftingMachineBlockEntity(BEP bep, MachineRecipeType recipeType, MachineInventoryComponent inventory,
             MachineGuiParameters guiParams, EnergyBar.Parameters energyBarParams, ProgressBar.Parameters progressBarParams,
@@ -131,5 +133,10 @@ public class ElectricCraftingMachineBlockEntity extends AbstractCraftingMachineB
     @Override
     public EnergyComponent getEnergyComponent() {
         return energy;
+    }
+
+    @Override
+    public CableTier getCableTier() {
+        return casing.getCableTier();
     }
 }

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/ElectricWaterPumpBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/ElectricWaterPumpBlockEntity.java
@@ -25,6 +25,7 @@ package aztech.modern_industrialization.machines.blockentities;
 
 import aztech.modern_industrialization.MICapabilities;
 import aztech.modern_industrialization.api.energy.CableTier;
+import aztech.modern_industrialization.api.energy.CableTierHolder;
 import aztech.modern_industrialization.api.energy.EnergyApi;
 import aztech.modern_industrialization.api.energy.MIEnergyStorage;
 import aztech.modern_industrialization.api.machine.holder.EnergyComponentHolder;
@@ -43,7 +44,7 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.fluids.FluidType;
 
-public class ElectricWaterPumpBlockEntity extends AbstractWaterPumpBlockEntity implements EnergyComponentHolder {
+public class ElectricWaterPumpBlockEntity extends AbstractWaterPumpBlockEntity implements EnergyComponentHolder, CableTierHolder {
     public ElectricWaterPumpBlockEntity(BEP bep) {
         super(bep, "electric_water_pump");
 
@@ -104,5 +105,10 @@ public class ElectricWaterPumpBlockEntity extends AbstractWaterPumpBlockEntity i
         MICapabilities.onEvent(event -> {
             event.registerBlockEntity(EnergyApi.SIDED, bet, (be, direction) -> ((ElectricWaterPumpBlockEntity) be).insertable);
         });
+    }
+
+    @Override
+    public CableTier getCableTier() {
+        return CableTier.LV;
     }
 }

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/GeneratorMachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/GeneratorMachineBlockEntity.java
@@ -27,6 +27,7 @@ import static aztech.modern_industrialization.machines.components.FluidItemConsu
 
 import aztech.modern_industrialization.MICapabilities;
 import aztech.modern_industrialization.api.energy.CableTier;
+import aztech.modern_industrialization.api.energy.CableTierHolder;
 import aztech.modern_industrialization.api.energy.EnergyApi;
 import aztech.modern_industrialization.api.energy.MIEnergyStorage;
 import aztech.modern_industrialization.api.machine.holder.EnergyComponentHolder;
@@ -50,7 +51,7 @@ import java.util.List;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 
-public class GeneratorMachineBlockEntity extends MachineBlockEntity implements Tickable, EnergyComponentHolder {
+public class GeneratorMachineBlockEntity extends MachineBlockEntity implements Tickable, EnergyComponentHolder, CableTierHolder {
 
     private final CableTier outputTier;
     private final MIEnergyStorage extractable;
@@ -211,5 +212,10 @@ public class GeneratorMachineBlockEntity extends MachineBlockEntity implements T
     @Override
     public List<Component> getTooltips() {
         return fluidItemConsumer.getTooltips();
+    }
+
+    @Override
+    public CableTier getCableTier() {
+        return outputTier;
     }
 }

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/StorageMachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/StorageMachineBlockEntity.java
@@ -24,10 +24,11 @@
 package aztech.modern_industrialization.machines.blockentities;
 
 import aztech.modern_industrialization.api.energy.CableTier;
+import aztech.modern_industrialization.api.energy.CableTierHolder;
 import aztech.modern_industrialization.machines.BEP;
 import net.minecraft.util.Mth;
 
-public class StorageMachineBlockEntity extends AbstractStorageMachineBlockEntity {
+public class StorageMachineBlockEntity extends AbstractStorageMachineBlockEntity implements CableTierHolder {
 
     public StorageMachineBlockEntity(BEP bep, CableTier tier, String name, long eu_capacity) {
         super(bep, tier, tier, name, eu_capacity);
@@ -42,5 +43,10 @@ public class StorageMachineBlockEntity extends AbstractStorageMachineBlockEntity
     protected int getComparatorOutput() {
         double fillPercentage = (double) energy.getEu() / energy.getCapacity();
         return Mth.floor(fillPercentage * 14) + (energy.getEu() > 0 ? 1 : 0);
+    }
+
+    @Override
+    public CableTier getCableTier() {
+        return to;
     }
 }

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/EnergyHatch.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/EnergyHatch.java
@@ -25,6 +25,7 @@ package aztech.modern_industrialization.machines.blockentities.hatches;
 
 import aztech.modern_industrialization.MICapabilities;
 import aztech.modern_industrialization.api.energy.CableTier;
+import aztech.modern_industrialization.api.energy.CableTierHolder;
 import aztech.modern_industrialization.api.energy.EnergyApi;
 import aztech.modern_industrialization.api.energy.MIEnergyStorage;
 import aztech.modern_industrialization.api.machine.holder.EnergyComponentHolder;
@@ -39,12 +40,13 @@ import aztech.modern_industrialization.machines.multiblocks.HatchType;
 import java.util.List;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 
-public class EnergyHatch extends HatchBlockEntity implements EnergyComponentHolder {
+public class EnergyHatch extends HatchBlockEntity implements EnergyComponentHolder, CableTierHolder {
 
     public EnergyHatch(BEP bep, String name, boolean input, CableTier tier) {
         super(bep, new MachineGuiParameters.Builder(name, false).build(), new OrientationComponent.Params(!input, false, false));
 
         this.input = input;
+        this.tier = tier;
 
         this.energy = new EnergyComponent(this, 30 * 20 * tier.getEu());
         insertable = energy.buildInsertable((CableTier tier2) -> tier2 == tier);
@@ -55,7 +57,8 @@ public class EnergyHatch extends HatchBlockEntity implements EnergyComponentHold
         this.registerComponents(energy);
     }
 
-    private final boolean input;
+    protected final boolean input;
+    protected final CableTier tier;
 
     protected final EnergyComponent energy;
     protected final MIEnergyStorage insertable;
@@ -69,6 +72,11 @@ public class EnergyHatch extends HatchBlockEntity implements EnergyComponentHold
     @Override
     public boolean upgradesToSteel() {
         return false;
+    }
+
+    @Override
+    public CableTier getCableTier() {
+        return tier;
     }
 
     @Override

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/EnergyHatch.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/EnergyHatch.java
@@ -57,12 +57,12 @@ public class EnergyHatch extends HatchBlockEntity implements EnergyComponentHold
         this.registerComponents(energy);
     }
 
-    protected final boolean input;
-    protected final CableTier tier;
+    private final boolean input;
+    private final CableTier tier;
 
-    protected final EnergyComponent energy;
-    protected final MIEnergyStorage insertable;
-    protected final MIEnergyStorage extractable;
+    private final EnergyComponent energy;
+    private final MIEnergyStorage insertable;
+    private final MIEnergyStorage extractable;
 
     @Override
     public HatchType getHatchType() {

--- a/src/main/java/aztech/modern_industrialization/machines/components/CasingComponent.java
+++ b/src/main/java/aztech/modern_industrialization/machines/components/CasingComponent.java
@@ -24,7 +24,6 @@
 package aztech.modern_industrialization.machines.components;
 
 import aztech.modern_industrialization.api.energy.CableTier;
-import aztech.modern_industrialization.api.energy.CableTierHolder;
 import aztech.modern_industrialization.machines.IComponent;
 import aztech.modern_industrialization.machines.MachineBlockEntity;
 import aztech.modern_industrialization.machines.models.MachineCasing;
@@ -43,15 +42,31 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import org.jetbrains.annotations.Nullable;
 
-public class CasingComponent implements IComponent, DropableComponent, CableTierHolder {
+public class CasingComponent implements IComponent, DropableComponent {
 
-    protected ItemStack casingStack = ItemStack.EMPTY;
-    protected CableTier currentTier = CableTier.LV;
+    @FunctionalInterface
+    public interface UpdatedCallback {
+        void onUpdated(CableTier from, CableTier to);
+    }
+
+    @Nullable
+    private final UpdatedCallback callback;
+
+    private ItemStack casingStack = ItemStack.EMPTY;
+    private CableTier currentTier = CableTier.LV;
+
+    public CasingComponent(@Nullable UpdatedCallback callback) {
+        this.callback = callback;
+    }
+
+    public CasingComponent() {
+        this(null);
+    }
 
     /**
      * Sets the current casing stack and update {@link #currentTier} accordingly.
      */
-    protected void setCasingStack(ItemStack stack) {
+    private void setCasingStack(ItemStack stack) {
         casingStack = stack;
 
         // Compute tier
@@ -81,7 +96,6 @@ public class CasingComponent implements IComponent, DropableComponent, CableTier
         currentTier = CableTier.getTier(tag.getString("casing"));
     }
 
-    @Override
     public CableTier getCableTier() {
         return currentTier;
     }
@@ -93,6 +107,7 @@ public class CasingComponent implements IComponent, DropableComponent, CableTier
     public ItemInteractionResult onUse(MachineBlockEntity be, Player player, InteractionHand hand) {
         ItemStack stackInHand = player.getItemInHand(hand);
         if (stackInHand.getCount() >= 1) {
+            var previousTier = currentTier;
             var newTier = getCasingTier(stackInHand.getItem());
             if (newTier != null && newTier != currentTier) {
                 if (currentTier != CableTier.LV) {
@@ -109,13 +124,16 @@ public class CasingComponent implements IComponent, DropableComponent, CableTier
                 be.getLevel().updateNeighborsAt(be.getBlockPos(), Blocks.AIR);
                 // Play a nice sound :)
                 playCasingPlaceSound(be);
+                if (callback != null) {
+                    callback.onUpdated(previousTier, currentTier);
+                }
                 return ItemInteractionResult.sidedSuccess(be.getLevel().isClientSide);
             }
         }
         return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
     }
 
-    protected void playCasingPlaceSound(MachineBlockEntity be) {
+    private void playCasingPlaceSound(MachineBlockEntity be) {
         var blockKey = currentTier.itemKey;
         if (blockKey == null) {
             return; // no sound for LV
@@ -148,11 +166,15 @@ public class CasingComponent implements IComponent, DropableComponent, CableTier
     }
 
     public void setCasingServer(MachineBlockEntity be, ItemStack casing) {
+        var previousTier = currentTier;
         setCasingStack(casing);
         be.setChanged();
         be.sync();
         be.getLevel().updateNeighborsAt(be.getBlockPos(), Blocks.AIR);
         playCasingPlaceSound(be);
+        if (callback != null && previousTier != currentTier) {
+            callback.onUpdated(previousTier, currentTier);
+        }
     }
 
     public MachineCasing getCasing() {

--- a/src/main/java/aztech/modern_industrialization/machines/components/CasingComponent.java
+++ b/src/main/java/aztech/modern_industrialization/machines/components/CasingComponent.java
@@ -24,6 +24,7 @@
 package aztech.modern_industrialization.machines.components;
 
 import aztech.modern_industrialization.api.energy.CableTier;
+import aztech.modern_industrialization.api.energy.CableTierHolder;
 import aztech.modern_industrialization.machines.IComponent;
 import aztech.modern_industrialization.machines.MachineBlockEntity;
 import aztech.modern_industrialization.machines.models.MachineCasing;
@@ -42,15 +43,15 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import org.jetbrains.annotations.Nullable;
 
-public class CasingComponent implements IComponent, DropableComponent {
+public class CasingComponent implements IComponent, DropableComponent, CableTierHolder {
 
-    private ItemStack casingStack = ItemStack.EMPTY;
-    private CableTier currentTier = CableTier.LV;
+    protected ItemStack casingStack = ItemStack.EMPTY;
+    protected CableTier currentTier = CableTier.LV;
 
     /**
      * Sets the current casing stack and update {@link #currentTier} accordingly.
      */
-    private void setCasingStack(ItemStack stack) {
+    protected void setCasingStack(ItemStack stack) {
         casingStack = stack;
 
         // Compute tier
@@ -78,6 +79,11 @@ public class CasingComponent implements IComponent, DropableComponent {
     @Override
     public void readClientNbt(CompoundTag tag, HolderLookup.Provider registries) {
         currentTier = CableTier.getTier(tag.getString("casing"));
+    }
+
+    @Override
+    public CableTier getCableTier() {
+        return currentTier;
     }
 
     public void dropCasing(Level world, BlockPos pos) {
@@ -109,7 +115,7 @@ public class CasingComponent implements IComponent, DropableComponent {
         return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
     }
 
-    private void playCasingPlaceSound(MachineBlockEntity be) {
+    protected void playCasingPlaceSound(MachineBlockEntity be) {
         var blockKey = currentTier.itemKey;
         if (blockKey == null) {
             return; // no sound for LV


### PR DESCRIPTION
Contains some parts of #900 

It might make sense to also add the `CableTierHolder` interface to electric machines and get the tier from their casing component. That can easily be done. Doing it for multi blocks is a little ambiguous since a multi block electric machine can have multiple types of hatches on it. It could just use the highest tier, though. Would either of these changes be acceptable?