### PR TITLE
Buff motors being used as item pipe upgrades

### DIFF
--- a/src/generated/resources/data/modern_industrialization/data_maps/item/item_pipe_upgrades.json
+++ b/src/generated/resources/data/modern_industrialization/data_maps/item/item_pipe_upgrades.json
@@ -1,13 +1,13 @@
 {
   "values": {
     "modern_industrialization:advanced_motor": {
-      "maxExtractedItems": 32
-    },
-    "modern_industrialization:large_advanced_motor": {
       "maxExtractedItems": 64
     },
+    "modern_industrialization:large_advanced_motor": {
+      "maxExtractedItems": 512
+    },
     "modern_industrialization:large_motor": {
-      "maxExtractedItems": 8
+      "maxExtractedItems": 16
     },
     "modern_industrialization:motor": {
       "maxExtractedItems": 2

--- a/src/main/java/aztech/modern_industrialization/datagen/datamap/MIDataMapProvider.java
+++ b/src/main/java/aztech/modern_industrialization/datagen/datamap/MIDataMapProvider.java
@@ -99,9 +99,9 @@ public class MIDataMapProvider extends DataMapProvider {
 
     private void gatherItemPipeUpgrades() {
         addItemPipeUpgrade(MIItem.MOTOR, 2);
-        addItemPipeUpgrade(MIItem.LARGE_MOTOR, 8);
-        addItemPipeUpgrade(MIItem.ADVANCED_MOTOR, 32);
-        addItemPipeUpgrade(MIItem.LARGE_ADVANCED_MOTOR, 64);
+        addItemPipeUpgrade(MIItem.LARGE_MOTOR, 16);
+        addItemPipeUpgrade(MIItem.ADVANCED_MOTOR, 64);
+        addItemPipeUpgrade(MIItem.LARGE_ADVANCED_MOTOR, 512);
     }
 
     private void addItemPipeUpgrade(ItemDefinition<?> itemDefinition, int maxExtractedItems) {


### PR DESCRIPTION
Fixes #936. Not by following the x4 pattern, but rather by giving to motors the same scaling as machine upgrades.