### PR TITLE
Fix redstone control and overdrive modules getting consumed when applying in creative mode

### DIFF
--- a/src/main/java/aztech/modern_industrialization/machines/components/CasingComponent.java
+++ b/src/main/java/aztech/modern_industrialization/machines/components/CasingComponent.java
@@ -114,9 +114,7 @@ public class CasingComponent implements IComponent, DropableComponent {
                     dropCasing(be.getLevel(), be.getBlockPos());
                 }
                 setCasingStack(stackInHand.copyWithCount(1));
-                if (!player.isCreative()) {
-                    stackInHand.shrink(1);
-                }
+                stackInHand.consume(1, player);
                 be.setChanged();
                 if (!be.getLevel().isClientSide()) {
                     be.sync();

--- a/src/main/java/aztech/modern_industrialization/machines/components/OverdriveComponent.java
+++ b/src/main/java/aztech/modern_industrialization/machines/components/OverdriveComponent.java
@@ -61,9 +61,8 @@ public class OverdriveComponent implements IComponent.ServerOnly, DropableCompon
             return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
         }
         if (MIItem.OVERDRIVE_MODULE.is(stackInHand) && overdriveModule.isEmpty()) {
-            overdriveModule = stackInHand.copy();
-            overdriveModule.setCount(1);
-            stackInHand.shrink(1);
+            overdriveModule = stackInHand.copyWithCount(1);
+            stackInHand.consume(1, player);
 
             be.setChanged();
             return ItemInteractionResult.sidedSuccess(player.level().isClientSide);

--- a/src/main/java/aztech/modern_industrialization/machines/components/RedstoneControlComponent.java
+++ b/src/main/java/aztech/modern_industrialization/machines/components/RedstoneControlComponent.java
@@ -66,9 +66,8 @@ public class RedstoneControlComponent implements IComponent.ServerOnly, Dropable
             return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
         }
         if (MIItem.REDSTONE_CONTROL_MODULE.is(stackInHand) && controlModule.isEmpty()) {
-            controlModule = stackInHand.copy();
-            controlModule.setCount(1);
-            stackInHand.shrink(1);
+            controlModule = stackInHand.copyWithCount(1);
+            stackInHand.consume(1, player);
 
             be.setChanged();
             return ItemInteractionResult.sidedSuccess(player.level().isClientSide);

--- a/src/main/java/aztech/modern_industrialization/machines/components/UpgradeComponent.java
+++ b/src/main/java/aztech/modern_industrialization/machines/components/UpgradeComponent.java
@@ -76,9 +76,7 @@ public class UpgradeComponent implements IComponent.ServerOnly, DropableComponen
                 int maxAdded = Math.min(stackInHand.getCount(), itemStack.getMaxStackSize() - itemStack.getCount());
                 changed = maxAdded > 0;
                 itemStack.grow(maxAdded);
-                if (!player.isCreative()) {
-                    stackInHand.shrink(maxAdded);
-                }
+                stackInHand.consume(maxAdded, player);
             }
             if (changed) {
                 be.setChanged();


### PR DESCRIPTION
Also updates all the item holding machine components to use `consume(...)` instead of `shrink(...)` and `copyWithCount(...)` instead of `copy()` and then `setCount(...)`