### PR TITLE
Fix #935: Machine output slots getting stuck in an invisible locked state

### DIFF
--- a/src/main/java/aztech/modern_industrialization/machines/components/CrafterComponent.java
+++ b/src/main/java/aztech/modern_industrialization/machines/components/CrafterComponent.java
@@ -523,18 +523,19 @@ public class CrafterComponent implements IComponent.ServerOnly, CrafterAccess {
                                 ? (int) stack.getRemainingCapacityFor(output.variant())
                                 : output.variant().getMaxStackSize() - (int) stack.getAmount();
                         int ins = Math.min(remainingAmount, remainingCapacity);
-                        if (key.isBlank()) {
-                            if ((stack.isMachineLocked() || stack.isPlayerLocked() || loopRun == 1) && stack.isValid(output.getStack())) {
-                                stack.setAmount(ins);
-                                stack.setKey(output.variant());
-                            } else {
-                                ins = 0;
-                            }
-                        } else {
-                            stack.increment(ins);
-                        }
-                        remainingAmount -= ins;
                         if (ins > 0) {
+                            if (key.isBlank()) {
+                                if ((stack.isMachineLocked() || stack.isPlayerLocked() || loopRun == 1) && stack.isValid(output.getStack())) {
+                                    stack.setAmount(ins);
+                                    stack.setKey(output.variant());
+                                } else {
+                                    ins = 0;
+                                }
+                            } else {
+                                stack.increment(ins);
+                            }
+                            remainingAmount -= ins;
+
                             locksToToggle.add(stackId - 1);
                             lockItems.add(output.variant().getItem());
                             if (!simulate) {


### PR DESCRIPTION
Issue #935 could be reproduced with the following procedure:
- Set capacity of the first 3 slots to 0.
- Insert a single iron ingot and wait for the dust to appear in the 4th slot.
- Increase capacity of first slots back to 64.
- Insert a single copper ingot.
- Notice that no recipe starts.

The problem comes from `stack.setKey(output.variant());` being called while `ins` is `0`. The fix is to add a check for `ins > 0`.