### PR TITLE
Fix #674: Buff cryofluid hot ingot cooling. Tweak cryofluid fabrication recipe to make it more readable

### DIFF
--- a/src/generated/resources/data/modern_industrialization/recipe/materials/annealed_copper/heat_exchanger/hot_ingot.json
+++ b/src/generated/resources/data/modern_industrialization/recipe/materials/annealed_copper/heat_exchanger/hot_ingot.json
@@ -4,17 +4,17 @@
   "eu": 8,
   "fluid_inputs": [
     {
-      "amount": 100,
+      "amount": 20,
       "fluid": "modern_industrialization:cryofluid"
     }
   ],
   "fluid_outputs": [
     {
-      "amount": 65,
+      "amount": 13,
       "fluid": "modern_industrialization:argon"
     },
     {
-      "amount": 25,
+      "amount": 5,
       "fluid": "modern_industrialization:helium"
     }
   ],

--- a/src/generated/resources/data/modern_industrialization/recipe/materials/chromium/heat_exchanger/hot_ingot.json
+++ b/src/generated/resources/data/modern_industrialization/recipe/materials/chromium/heat_exchanger/hot_ingot.json
@@ -4,17 +4,17 @@
   "eu": 8,
   "fluid_inputs": [
     {
-      "amount": 100,
+      "amount": 20,
       "fluid": "modern_industrialization:cryofluid"
     }
   ],
   "fluid_outputs": [
     {
-      "amount": 65,
+      "amount": 13,
       "fluid": "modern_industrialization:argon"
     },
     {
-      "amount": 25,
+      "amount": 5,
       "fluid": "modern_industrialization:helium"
     }
   ],

--- a/src/generated/resources/data/modern_industrialization/recipe/materials/kanthal/heat_exchanger/hot_ingot.json
+++ b/src/generated/resources/data/modern_industrialization/recipe/materials/kanthal/heat_exchanger/hot_ingot.json
@@ -4,17 +4,17 @@
   "eu": 8,
   "fluid_inputs": [
     {
-      "amount": 100,
+      "amount": 20,
       "fluid": "modern_industrialization:cryofluid"
     }
   ],
   "fluid_outputs": [
     {
-      "amount": 65,
+      "amount": 13,
       "fluid": "modern_industrialization:argon"
     },
     {
-      "amount": 25,
+      "amount": 5,
       "fluid": "modern_industrialization:helium"
     }
   ],

--- a/src/generated/resources/data/modern_industrialization/recipe/materials/platinum/heat_exchanger/hot_ingot.json
+++ b/src/generated/resources/data/modern_industrialization/recipe/materials/platinum/heat_exchanger/hot_ingot.json
@@ -4,17 +4,17 @@
   "eu": 8,
   "fluid_inputs": [
     {
-      "amount": 100,
+      "amount": 20,
       "fluid": "modern_industrialization:cryofluid"
     }
   ],
   "fluid_outputs": [
     {
-      "amount": 65,
+      "amount": 13,
       "fluid": "modern_industrialization:argon"
     },
     {
-      "amount": 25,
+      "amount": 5,
       "fluid": "modern_industrialization:helium"
     }
   ],

--- a/src/generated/resources/data/modern_industrialization/recipe/materials/stainless_steel/heat_exchanger/hot_ingot.json
+++ b/src/generated/resources/data/modern_industrialization/recipe/materials/stainless_steel/heat_exchanger/hot_ingot.json
@@ -4,17 +4,17 @@
   "eu": 8,
   "fluid_inputs": [
     {
-      "amount": 100,
+      "amount": 20,
       "fluid": "modern_industrialization:cryofluid"
     }
   ],
   "fluid_outputs": [
     {
-      "amount": 65,
+      "amount": 13,
       "fluid": "modern_industrialization:argon"
     },
     {
-      "amount": 25,
+      "amount": 5,
       "fluid": "modern_industrialization:helium"
     }
   ],

--- a/src/generated/resources/data/modern_industrialization/recipe/materials/superconductor/heat_exchanger/hot_ingot.json
+++ b/src/generated/resources/data/modern_industrialization/recipe/materials/superconductor/heat_exchanger/hot_ingot.json
@@ -4,17 +4,17 @@
   "eu": 8,
   "fluid_inputs": [
     {
-      "amount": 100,
+      "amount": 20,
       "fluid": "modern_industrialization:cryofluid"
     }
   ],
   "fluid_outputs": [
     {
-      "amount": 65,
+      "amount": 13,
       "fluid": "modern_industrialization:argon"
     },
     {
-      "amount": 25,
+      "amount": 5,
       "fluid": "modern_industrialization:helium"
     }
   ],

--- a/src/generated/resources/data/modern_industrialization/recipe/materials/titanium/heat_exchanger/hot_ingot.json
+++ b/src/generated/resources/data/modern_industrialization/recipe/materials/titanium/heat_exchanger/hot_ingot.json
@@ -4,17 +4,17 @@
   "eu": 8,
   "fluid_inputs": [
     {
-      "amount": 100,
+      "amount": 20,
       "fluid": "modern_industrialization:cryofluid"
     }
   ],
   "fluid_outputs": [
     {
-      "amount": 65,
+      "amount": 13,
       "fluid": "modern_industrialization:argon"
     },
     {
-      "amount": 25,
+      "amount": 5,
       "fluid": "modern_industrialization:helium"
     }
   ],

--- a/src/main/java/aztech/modern_industrialization/materials/recipe/StandardRecipes.java
+++ b/src/main/java/aztech/modern_industrialization/materials/recipe/StandardRecipes.java
@@ -166,8 +166,8 @@ public final class StandardRecipes {
 
         // HEAT EXCHANGER
         new MIRecipeBuilder(ctx, MIMachineRecipeTypes.HEAT_EXCHANGER, "hot_ingot", 8, 10).addPartInput(HOT_INGOT, 1)
-                .addFluidInput(MIFluids.CRYOFLUID, 100)
-                .addPartOutput(INGOT, 1).addFluidOutput(MIFluids.ARGON, 65).addFluidOutput(MIFluids.HELIUM, 25);
+                .addFluidInput(MIFluids.CRYOFLUID, 20)
+                .addPartOutput(INGOT, 1).addFluidOutput(MIFluids.ARGON, 13).addFluidOutput(MIFluids.HELIUM, 5);
 
         new MIRecipeBuilder(ctx, MIMachineRecipeTypes.POLARIZER, "rod_magnetic", 8, 200).addTaggedPartInput(ROD, 1).addPartOutput(ROD_MAGNETIC, 1);
         new MIRecipeBuilder(ctx, MIMachineRecipeTypes.POLARIZER, "wire_magnetic", 8, 200).addTaggedPartInput(WIRE, 1).addPartOutput(WIRE_MAGNETIC, 1);

--- a/src/main/resources/data/modern_industrialization/recipe/materials/vacuum_freezer/cryofluid.json
+++ b/src/main/resources/data/modern_industrialization/recipe/materials/vacuum_freezer/cryofluid.json
@@ -1,23 +1,22 @@
 {
   "type": "modern_industrialization:vacuum_freezer",
-  "eu": 64,
+  "eu": 256,
   "duration" : 250,
 
   "fluid_inputs" :
       [
         {
         "fluid" : "modern_industrialization:argon",
-        "amount": 35
+        "amount": 140
         },
         {
           "fluid" : "modern_industrialization:helium",
-          "amount": 15
+          "amount": 60
         }
   ],
 
   "fluid_outputs": {
     "fluid" : "modern_industrialization:cryofluid",
-    "amount" : 50
+    "amount" : 200
   }
-
 }


### PR DESCRIPTION
Cooling a hot ingot now only requires 20 mb of cryofluid. To make ratios more readable, the recipe to create cryofluid now produces it in batches of 200 mb rather than 50 mb.