### PR TITLE
Fix EMI warnings for synthetic recipe ids

### DIFF
--- a/src/client/java/aztech/modern_industrialization/compat/viewer/usage/FluidFuelsCategory.java
+++ b/src/client/java/aztech/modern_industrialization/compat/viewer/usage/FluidFuelsCategory.java
@@ -77,6 +77,6 @@ public class FluidFuelsCategory extends ViewerCategory<Fluid> {
 
     @Override
     public ResourceLocation getRecipeId(Fluid recipe) {
-        return MI.id("fluid_fuels/" + BuiltInRegistries.FLUID.getKey(recipe).toString().replace(':', '_'));
+        return MI.id("/fluid_fuels/" + BuiltInRegistries.FLUID.getKey(recipe).toString().replace(':', '_'));
     }
 }

--- a/src/client/java/aztech/modern_industrialization/compat/viewer/usage/MultiblockCategory.java
+++ b/src/client/java/aztech/modern_industrialization/compat/viewer/usage/MultiblockCategory.java
@@ -109,7 +109,7 @@ public class MultiblockCategory extends ViewerCategory<MultiblockCategory.Recipe
                 this.materials.add(new ItemStack(entry.getKey(), entry.getValue()));
             }
             this.id = ResourceLocation.fromNamespaceAndPath(controller.getNamespace(),
-                    controller.getPath() + "/" + materials.size() + (alternative == null ? "" : "/" + alternative));
+                    "/" + controller.getPath() + "/" + materials.size() + (alternative == null ? "" : "/" + alternative));
         }
     }
 }

--- a/src/main/java/aztech/modern_industrialization/machines/recipe/RecipeConversions.java
+++ b/src/main/java/aztech/modern_industrialization/machines/recipe/RecipeConversions.java
@@ -45,7 +45,7 @@ import org.jetbrains.annotations.Nullable;
 public class RecipeConversions {
 
     public static RecipeHolder<MachineRecipe> ofSmelting(RecipeHolder<SmeltingRecipe> holder, MachineRecipeType type, RegistryAccess registryAccess) {
-        ResourceLocation id = ResourceLocation.fromNamespaceAndPath(holder.id().getNamespace(), holder.id().getPath() + "_exported_mi_furnace");
+        ResourceLocation id = ResourceLocation.fromNamespaceAndPath(holder.id().getNamespace(), "/" + holder.id().getPath() + "_exported_mi_furnace");
         var smeltingRecipe = holder.value();
         Ingredient ingredient = smeltingRecipe.getIngredients().get(0);
         MachineRecipe recipe = new MachineRecipe(type);
@@ -62,7 +62,7 @@ public class RecipeConversions {
     public static RecipeHolder<MachineRecipe> ofStonecutting(RecipeHolder<StonecutterRecipe> holder, MachineRecipeType type,
             RegistryAccess registryAccess) {
         ResourceLocation id = ResourceLocation.fromNamespaceAndPath(holder.id().getNamespace(),
-                holder.id().getPath() + "_exported_mi_cutting_machine");
+                "/" + holder.id().getPath() + "_exported_mi_cutting_machine");
         var stonecuttingRecipe = holder.value();
         MachineRecipe recipe = new MachineRecipe(type);
         recipe.eu = 2;
@@ -85,7 +85,7 @@ public class RecipeConversions {
 
         float probability = ComposterBlock.COMPOSTABLES.getOrDefault(compostable.asItem(), 0.0F);
         if (probability > 0.0F) {
-            ResourceLocation id = MI.id(BuiltInRegistries.ITEM.getKey(compostable.asItem()).getPath() + "_to_plant_oil");
+            ResourceLocation id = MI.id("/" + BuiltInRegistries.ITEM.getKey(compostable.asItem()).getPath() + "_to_plant_oil");
             MachineRecipe plantOil = new MachineRecipe(MIMachineRecipeTypes.CENTRIFUGE);
             plantOil.eu = 8;
             plantOil.duration = 200;

--- a/src/main/java/aztech/modern_industrialization/nuclear/INuclearComponent.java
+++ b/src/main/java/aztech/modern_industrialization/nuclear/INuclearComponent.java
@@ -56,9 +56,9 @@ public interface INuclearComponent<T extends TransferVariant> {
     static ResourceLocation getEmiRecipeId(INuclearComponent<?> component, String category, String type) {
         return switch (component.getVariant()) {
         case ItemVariant itemVariant ->
-            BuiltInRegistries.ITEM.getKey(itemVariant.getItem()).withPrefix(category + "/item/").withSuffix("/" + type);
+            BuiltInRegistries.ITEM.getKey(itemVariant.getItem()).withPrefix("/" + category + "/item/").withSuffix("/" + type);
         case FluidVariant fluidVariant ->
-            BuiltInRegistries.FLUID.getKey(fluidVariant.getFluid()).withPrefix(category + "/fluid/").withSuffix("/" + type);
+            BuiltInRegistries.FLUID.getKey(fluidVariant.getFluid()).withPrefix("/" + category + "/fluid/").withSuffix("/" + type);
         case Object object -> throw new IllegalArgumentException("Unknown component variant " + object);
         };
     }


### PR DESCRIPTION
EMI puts out quite a bit of warnings when recipes aren't in the recipe manager and don't use a forward slash after the semicolon in recipe ids.