### PR TITLE
Pipe Config Card to extract blocks from items containing items (such as Banks from Bank Storage)

### DIFF
--- a/src/main/java/aztech/modern_industrialization/pipes/impl/PipeBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/pipes/impl/PipeBlockEntity.java
@@ -66,7 +66,6 @@ import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.neoforged.neoforge.client.model.data.ModelData;
 import net.neoforged.neoforge.client.model.data.ModelProperty;
-import net.neoforged.neoforge.items.wrapper.PlayerInvWrapper;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -351,7 +350,7 @@ public class PipeBlockEntity extends FastBlockEntity implements IPipeScreenHandl
 
         if (!player.getAbilities().instabuild && itemChanged) {
             var itemToUse = newCamouflage.getBlock().asItem();
-            var extracted = TransferHelper.extractMatching(new PlayerInvWrapper(player.getInventory()), s -> s.is(itemToUse), 1, true);
+            var extracted = TransferHelper.extractMatching(player.getInventory(), s -> s.is(itemToUse), 1, true);
 
             if (extracted.isEmpty()) {
                 player.displayClientMessage(MITooltips.line(MIText.ConfigCardNoCamouflageInInventory)

--- a/src/main/java/aztech/modern_industrialization/pipes/impl/PipeBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/pipes/impl/PipeBlockEntity.java
@@ -253,7 +253,11 @@ public class PipeBlockEntity extends FastBlockEntity implements IPipeScreenHandl
     /**
      * Set the camouflage directly. The camouflage block should be consumed from the player before calling this.
      */
-    private void setCamouflage(Player player, @Nullable BlockState newCamouflage) {
+    private void setCamouflage(@Nullable BlockState newCamouflage) {
+        if (level.isClientSide) {
+            throw new IllegalStateException("Cannot call setCamouflage on the client");
+        }
+
         boolean hadCamouflage = hasCamouflage();
 
         if (camouflage != null) {
@@ -267,16 +271,14 @@ public class PipeBlockEntity extends FastBlockEntity implements IPipeScreenHandl
             if (newCamouflage == null) {
                 var group = camouflage.getSoundType();
                 var sound = group.getBreakSound();
-                level.playSound(player, worldPosition, sound, SoundSource.BLOCKS, (group.getVolume() + 1.0F) / 4.0F, group.getPitch() * 0.8F);
+                level.playSound(null, worldPosition, sound, SoundSource.BLOCKS, (group.getVolume() + 1.0F) / 4.0F, group.getPitch() * 0.8F);
             }
 
             // Remove camouflage
             camouflage = null;
             setChanged();
-            if (!level.isClientSide()) {
-                sync();
-                rebuildCollisionShape();
-            }
+            sync();
+            rebuildCollisionShape();
         }
 
         camouflage = newCamouflage;
@@ -285,13 +287,11 @@ public class PipeBlockEntity extends FastBlockEntity implements IPipeScreenHandl
             // Play a cool sound
             var group = newCamouflage.getSoundType();
             var sound = group.getPlaceSound();
-            level.playSound(player, worldPosition, sound, SoundSource.BLOCKS, (group.getVolume() + 1.0F) / 4.0F, group.getPitch() * 0.8F);
+            level.playSound(null, worldPosition, sound, SoundSource.BLOCKS, (group.getVolume() + 1.0F) / 4.0F, group.getPitch() * 0.8F);
 
             setChanged();
-            if (!level.isClientSide()) {
-                sync();
-                rebuildCollisionShape();
-            }
+            sync();
+            rebuildCollisionShape();
         }
 
         if (hadCamouflage != hasCamouflage()) {
@@ -310,7 +310,9 @@ public class PipeBlockEntity extends FastBlockEntity implements IPipeScreenHandl
             return false;
         }
 
-        setCamouflage(player, null);
+        if (!player.level().isClientSide) {
+            setCamouflage(null);
+        }
 
         return true;
     }
@@ -340,11 +342,16 @@ public class PipeBlockEntity extends FastBlockEntity implements IPipeScreenHandl
             return true;
         }
 
+        // Item capabilities shouldn't be messed with (and in some cases cannot - leading to inconsistent behavior) on the client side
+        if (player.level().isClientSide) {
+            return true;
+        }
+
         boolean itemChanged = camouflage == null || newCamouflage.getBlock() != camouflage.getBlock();
 
         if (!player.getAbilities().instabuild && itemChanged) {
             var itemToUse = newCamouflage.getBlock().asItem();
-            var extracted = TransferHelper.extractMatching(new PlayerInvWrapper(player.getInventory()), s -> s.is(itemToUse), 1);
+            var extracted = TransferHelper.extractMatching(new PlayerInvWrapper(player.getInventory()), s -> s.is(itemToUse), 1, true);
 
             if (extracted.isEmpty()) {
                 player.displayClientMessage(MITooltips.line(MIText.ConfigCardNoCamouflageInInventory)
@@ -353,7 +360,7 @@ public class PipeBlockEntity extends FastBlockEntity implements IPipeScreenHandl
             }
         }
 
-        setCamouflage(player, newCamouflage);
+        setCamouflage(newCamouflage);
         return true;
     }
 

--- a/src/main/java/aztech/modern_industrialization/pipes/item/ItemNetworkNode.java
+++ b/src/main/java/aztech/modern_industrialization/pipes/item/ItemNetworkNode.java
@@ -61,7 +61,6 @@ import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.capabilities.BlockCapabilityCache;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.items.IItemHandler;
-import net.neoforged.neoforge.items.wrapper.PlayerInvWrapper;
 import org.jetbrains.annotations.Nullable;
 
 public class ItemNetworkNode extends PipeNetworkNode {
@@ -371,7 +370,7 @@ public class ItemNetworkNode extends PipeNetworkNode {
         }
 
         private int fetchItems(Player player, ItemVariant what, int maxAmount) {
-            return TransferHelper.extractMatching(new PlayerInvWrapper(player.getInventory()), what::matches, maxAmount, false).getCount();
+            return TransferHelper.extractMatching(player.getInventory(), what::matches, maxAmount, false).getCount();
         }
 
         private class ScreenHandlerFactory implements IPipeMenuProvider {

--- a/src/main/java/aztech/modern_industrialization/pipes/item/ItemNetworkNode.java
+++ b/src/main/java/aztech/modern_industrialization/pipes/item/ItemNetworkNode.java
@@ -371,7 +371,7 @@ public class ItemNetworkNode extends PipeNetworkNode {
         }
 
         private int fetchItems(Player player, ItemVariant what, int maxAmount) {
-            return TransferHelper.extractMatching(new PlayerInvWrapper(player.getInventory()), what::matches, maxAmount).getCount();
+            return TransferHelper.extractMatching(new PlayerInvWrapper(player.getInventory()), what::matches, maxAmount, false).getCount();
         }
 
         private class ScreenHandlerFactory implements IPipeMenuProvider {

--- a/src/main/java/aztech/modern_industrialization/util/TransferHelper.java
+++ b/src/main/java/aztech/modern_industrialization/util/TransferHelper.java
@@ -30,6 +30,7 @@ import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.items.IItemHandler;
 import net.neoforged.neoforge.items.ItemHandlerHelper;
+import net.neoforged.neoforge.items.wrapper.PlayerInvWrapper;
 
 public class TransferHelper {
     public static void moveAll(IItemHandler src, IItemHandler target, boolean stackInTarget) {
@@ -69,26 +70,44 @@ public class TransferHelper {
         }
     }
 
-    private interface ItemExtractor {
-        ItemStack get(int slot);
+    public static ItemStack extractMatching(Inventory inventory, Predicate<ItemStack> predicate, int maxAmount, boolean containers) {
+        int srcSlots = inventory.getContainerSize();
 
-        ItemStack extract(int slot, int amount);
+        var ret = extractMatching(new PlayerInvWrapper(inventory), predicate, maxAmount);
+
+        // Try to extract from item containing items
+        if (containers) {
+            if (!ret.isEmpty()) {
+                final var finalRet = ret;
+                predicate = other -> ItemStack.isSameItemSameComponents(finalRet, other);
+            }
+            for (int slot = 0; slot < srcSlots && maxAmount > ret.getCount(); ++slot) {
+                var stack = inventory.getItem(slot);
+                var capability = stack.getCapability(Capabilities.ItemHandler.ITEM);
+                if (capability != null) {
+                    var extracted = extractMatching(capability, predicate, maxAmount);
+                    if (ret.isEmpty()) {
+                        ret = extracted;
+                    } else {
+                        ret.grow(extracted.getCount());
+                    }
+                }
+            }
+        }
+
+        return ret;
     }
 
-    private static ItemStack extractMatching(int srcSlots, ItemExtractor extractor, Predicate<ItemStack> predicate, int maxAmount,
-            boolean containers) {
+    public static ItemStack extractMatching(IItemHandler src, Predicate<ItemStack> predicate, int maxAmount) {
+        int srcSlots = src.getSlots();
+
         // Find first stack
         ItemStack ret = ItemStack.EMPTY;
         int slot;
         for (slot = 0; slot < srcSlots && ret.isEmpty(); ++slot) {
-            var stack = extractor.get(slot);
+            var stack = src.getStackInSlot(slot);
             if (predicate.test(stack)) {
-                ret = extractor.extract(slot, maxAmount);
-            } else if (containers) {
-                var capability = stack.getCapability(Capabilities.ItemHandler.ITEM);
-                if (capability != null) {
-                    ret = extractMatching(capability, predicate, maxAmount);
-                }
+                ret = src.extractItem(slot, maxAmount, false);
             }
         }
         if (ret.isEmpty()) {
@@ -97,41 +116,13 @@ public class TransferHelper {
 
         // Try to extract more
         for (; slot < srcSlots && maxAmount > ret.getCount(); ++slot) {
-            var stack = extractor.get(slot);
+            var stack = src.getStackInSlot(slot);
             if (ItemStack.isSameItemSameComponents(stack, ret)) {
-                var extracted = extractor.extract(slot, maxAmount - ret.getCount());
+                var extracted = src.extractItem(slot, maxAmount - ret.getCount(), false);
                 ret.grow(extracted.getCount());
             }
         }
 
         return ret;
-    }
-
-    public static ItemStack extractMatching(Inventory inventory, Predicate<ItemStack> predicate, int maxAmount, boolean containers) {
-        return extractMatching(inventory.getContainerSize(), new ItemExtractor() {
-            @Override
-            public ItemStack get(int slot) {
-                return inventory.getItem(slot);
-            }
-
-            @Override
-            public ItemStack extract(int slot, int amount) {
-                return inventory.removeItem(slot, amount);
-            }
-        }, predicate, maxAmount, containers);
-    }
-
-    public static ItemStack extractMatching(IItemHandler src, Predicate<ItemStack> predicate, int maxAmount) {
-        return extractMatching(src.getSlots(), new ItemExtractor() {
-            @Override
-            public ItemStack get(int slot) {
-                return src.getStackInSlot(slot);
-            }
-
-            @Override
-            public ItemStack extract(int slot, int amount) {
-                return src.extractItem(slot, amount, false);
-            }
-        }, predicate, maxAmount, false);
     }
 }

--- a/src/main/java/aztech/modern_industrialization/util/TransferHelper.java
+++ b/src/main/java/aztech/modern_industrialization/util/TransferHelper.java
@@ -83,6 +83,9 @@ public class TransferHelper {
             }
             for (int slot = 0; slot < srcSlots && maxAmount > ret.getCount(); ++slot) {
                 var stack = inventory.getItem(slot);
+                if (stack.getCount() != 1) {
+                    continue;
+                }
                 var capability = stack.getCapability(Capabilities.ItemHandler.ITEM);
                 if (capability != null) {
                     var extracted = extractMatching(capability, predicate, maxAmount);

--- a/src/main/java/aztech/modern_industrialization/util/TransferHelper.java
+++ b/src/main/java/aztech/modern_industrialization/util/TransferHelper.java
@@ -25,6 +25,7 @@ package aztech.modern_industrialization.util;
 
 import aztech.modern_industrialization.MI;
 import java.util.function.Predicate;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.items.IItemHandler;
@@ -68,45 +69,69 @@ public class TransferHelper {
         }
     }
 
-    public static ItemStack extractMatching(IItemHandler src, Predicate<ItemStack> predicate, int maxAmount, boolean recursive) {
-        int srcSlots = src.getSlots();
+    private interface ItemExtractor {
+        ItemStack get(int slot);
 
+        ItemStack extract(int slot, int amount);
+    }
+
+    private static ItemStack extractMatching(int srcSlots, ItemExtractor extractor, Predicate<ItemStack> predicate, int maxAmount,
+            boolean containers) {
         // Find first stack
         ItemStack ret = ItemStack.EMPTY;
         int slot;
         for (slot = 0; slot < srcSlots && ret.isEmpty(); ++slot) {
-            var stack = src.getStackInSlot(slot);
+            var stack = extractor.get(slot);
             if (predicate.test(stack)) {
-                ret = src.extractItem(slot, maxAmount, false);
-            } else if (recursive) {
+                ret = extractor.extract(slot, maxAmount);
+            } else if (containers) {
                 var capability = stack.getCapability(Capabilities.ItemHandler.ITEM);
                 if (capability != null) {
-                    ret = extractMatching(capability, predicate, maxAmount, false);
+                    ret = extractMatching(capability, predicate, maxAmount);
                 }
             }
         }
         if (ret.isEmpty()) {
             return ItemStack.EMPTY;
         }
-        final ItemStack finalRet = ret;
 
         // Try to extract more
-        ++slot;
-        for (; slot < srcSlots && maxAmount < ret.getCount(); ++slot) {
-            var stack = src.getStackInSlot(slot);
+        for (; slot < srcSlots && maxAmount > ret.getCount(); ++slot) {
+            var stack = extractor.get(slot);
             if (ItemStack.isSameItemSameComponents(stack, ret)) {
-                var extracted = src.extractItem(slot, maxAmount - ret.getCount(), true);
+                var extracted = extractor.extract(slot, maxAmount - ret.getCount());
                 ret.grow(extracted.getCount());
-            } else if (recursive) {
-                var capability = stack.getCapability(Capabilities.ItemHandler.ITEM);
-                if (capability != null) {
-                    var extracted = extractMatching(capability, s -> ItemStack.isSameItemSameComponents(s, finalRet), maxAmount - ret.getCount(),
-                            false);
-                    ret.grow(extracted.getCount());
-                }
             }
         }
 
         return ret;
+    }
+
+    public static ItemStack extractMatching(Inventory inventory, Predicate<ItemStack> predicate, int maxAmount, boolean containers) {
+        return extractMatching(inventory.getContainerSize(), new ItemExtractor() {
+            @Override
+            public ItemStack get(int slot) {
+                return inventory.getItem(slot);
+            }
+
+            @Override
+            public ItemStack extract(int slot, int amount) {
+                return inventory.removeItem(slot, amount);
+            }
+        }, predicate, maxAmount, containers);
+    }
+
+    public static ItemStack extractMatching(IItemHandler src, Predicate<ItemStack> predicate, int maxAmount) {
+        return extractMatching(src.getSlots(), new ItemExtractor() {
+            @Override
+            public ItemStack get(int slot) {
+                return src.getStackInSlot(slot);
+            }
+
+            @Override
+            public ItemStack extract(int slot, int amount) {
+                return src.extractItem(slot, amount, false);
+            }
+        }, predicate, maxAmount, false);
     }
 }

--- a/src/main/java/aztech/modern_industrialization/util/TransferHelper.java
+++ b/src/main/java/aztech/modern_industrialization/util/TransferHelper.java
@@ -88,7 +88,7 @@ public class TransferHelper {
                 }
                 var capability = stack.getCapability(Capabilities.ItemHandler.ITEM);
                 if (capability != null) {
-                    var extracted = extractMatching(capability, predicate, maxAmount);
+                    var extracted = extractMatching(capability, predicate, maxAmount - ret.getCount());
                     if (ret.isEmpty()) {
                         ret = extracted;
                     } else {

--- a/src/main/java/aztech/modern_industrialization/util/TransferHelper.java
+++ b/src/main/java/aztech/modern_industrialization/util/TransferHelper.java
@@ -26,6 +26,7 @@ package aztech.modern_industrialization.util;
 import aztech.modern_industrialization.MI;
 import java.util.function.Predicate;
 import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.items.IItemHandler;
 import net.neoforged.neoforge.items.ItemHandlerHelper;
 
@@ -67,7 +68,7 @@ public class TransferHelper {
         }
     }
 
-    public static ItemStack extractMatching(IItemHandler src, Predicate<ItemStack> predicate, int maxAmount) {
+    public static ItemStack extractMatching(IItemHandler src, Predicate<ItemStack> predicate, int maxAmount, boolean recursive) {
         int srcSlots = src.getSlots();
 
         // Find first stack
@@ -77,19 +78,32 @@ public class TransferHelper {
             var stack = src.getStackInSlot(slot);
             if (predicate.test(stack)) {
                 ret = src.extractItem(slot, maxAmount, false);
+            } else if (recursive) {
+                var capability = stack.getCapability(Capabilities.ItemHandler.ITEM);
+                if (capability != null) {
+                    ret = extractMatching(capability, predicate, maxAmount, false);
+                }
             }
         }
         if (ret.isEmpty()) {
             return ItemStack.EMPTY;
         }
+        final ItemStack finalRet = ret;
 
         // Try to extract more
         ++slot;
         for (; slot < srcSlots && maxAmount < ret.getCount(); ++slot) {
             var stack = src.getStackInSlot(slot);
-            if (ItemStack.matches(stack, ret)) {
+            if (ItemStack.isSameItemSameComponents(stack, ret)) {
                 var extracted = src.extractItem(slot, maxAmount - ret.getCount(), true);
                 ret.grow(extracted.getCount());
+            } else if (recursive) {
+                var capability = stack.getCapability(Capabilities.ItemHandler.ITEM);
+                if (capability != null) {
+                    var extracted = extractMatching(capability, s -> ItemStack.isSameItemSameComponents(s, finalRet), maxAmount - ret.getCount(),
+                            false);
+                    ret.grow(extracted.getCount());
+                }
             }
         }
 


### PR DESCRIPTION
A few things to comment on:

- The camouflage applying is now done entirely server-side, since item handler capabilities shouldn't be messed with on the client side. In the case of Bank Storage, they use a read-only item handler capability on the client side. Because of this, the "No _____ in inventory" actionbar was being displayed and sounds wouldn't always play because the client got a different result when extracting than the server did.

- `TransferHelper#extractMatching` had to get adjusted to allow for recursive item extracting.

  - It won't go any deeper than one level though, so no backpacks inside backpacks - for example. This might be worth changing? Would be as simple as passing `true` to the recursive calls.
  
  - `ItemStack#matches` checks against item count which is (likely?) not intended here, changed it to `ItemStack#isSameItemSameComponents` to retain functionality while also fixing this.