### PR TITLE
Change electric machine overclock formula

### DIFF
--- a/src/main/java/aztech/modern_industrialization/machines/components/CrafterComponent.java
+++ b/src/main/java/aztech/modern_industrialization/machines/components/CrafterComponent.java
@@ -385,13 +385,10 @@ public class CrafterComponent implements IComponent.ServerOnly, CrafterAccess {
         }
     }
 
-    public static double getEfficiencyOverclock(int efficiencyTicks) {
-        return Math.pow(2.0, efficiencyTicks / 32.0);
-    }
-
     private long getRecipeMaxEu(long recipeEu, long totalEu, int efficiencyTicks) {
         long baseEu = Math.max(behavior.getBaseRecipeEu(), recipeEu);
-        return Math.min(totalEu, Math.min((int) Math.floor(baseEu * getEfficiencyOverclock(efficiencyTicks)), behavior.getMaxRecipeEu()));
+        long overclockedEu = baseEu + efficiencyTicks * totalEu / (20*30);
+        return Math.min(totalEu, Math.min(overclockedEu, behavior.getMaxRecipeEu()));
     }
 
     private int getRecipeMaxEfficiencyTicks(MachineRecipe recipe) {

--- a/src/main/java/aztech/modern_industrialization/machines/components/CrafterComponent.java
+++ b/src/main/java/aztech/modern_industrialization/machines/components/CrafterComponent.java
@@ -387,7 +387,7 @@ public class CrafterComponent implements IComponent.ServerOnly, CrafterAccess {
 
     private long getRecipeMaxEu(long recipeEu, long totalEu, int efficiencyTicks) {
         long baseEu = Math.max(behavior.getBaseRecipeEu(), recipeEu);
-        long overclockedEu = baseEu + efficiencyTicks * totalEu / (20*30);
+        long overclockedEu = baseEu + efficiencyTicks * totalEu / (20 * 30);
         return Math.min(totalEu, Math.min(overclockedEu, behavior.getMaxRecipeEu()));
     }
 


### PR DESCRIPTION
According to my computations, it should now take `30 seconds * (1 + log(K) + log(recipe base time / 30 seconds))` time to craft `K` recipes, for large `K`.

For example to craft a recipe 128 times, it should be about `4 minutes + 30 seconds * log(recipe base time / 30 seconds)`.

The maximum overclock is now about 600... Efficiency cool-down can take a while, but that's an unintended side effect. 😈