### PR TITLE
Fix #1026: Don't render hatch/block previews further than 32 blocks away

### DIFF
--- a/src/client/java/aztech/modern_industrialization/machines/multiblocks/MultiblockMachineBER.java
+++ b/src/client/java/aztech/modern_industrialization/machines/multiblocks/MultiblockMachineBER.java
@@ -42,6 +42,8 @@ import net.minecraft.world.phys.AABB;
 import org.jetbrains.annotations.Nullable;
 
 public class MultiblockMachineBER extends MachineBlockEntityRenderer<MultiblockMachineBlockEntity> {
+    private static final double MAX_HIGHLIGHT_DISTANCE = 32.0;
+
     public MultiblockMachineBER(BlockEntityRendererProvider.Context ctx) {
         super(ctx);
     }
@@ -55,8 +57,14 @@ public class MultiblockMachineBER extends MachineBlockEntityRenderer<MultiblockM
         HatchType hatchType = getHeldHatchType();
         if (drawHighlights || hatchType != null) {
             ShapeMatcher matcher = be.createShapeMatcher();
+            var player = Minecraft.getInstance().player;
 
             for (BlockPos pos : matcher.getPositions()) {
+                if (player != null && player.distanceToSqr(pos.getX(), pos.getY(), pos.getZ()) > MAX_HIGHLIGHT_DISTANCE * MAX_HIGHLIGHT_DISTANCE) {
+                    // Skip blocks that are far from the player to mitigate FPS drops.
+                    continue;
+                }
+
                 matrices.pushPose();
                 matrices.translate(pos.getX() - be.getBlockPos().getX(), pos.getY() - be.getBlockPos().getY(), pos.getZ() - be.getBlockPos().getZ());
 


### PR DESCRIPTION
Also fixes #983 as far as I am concerned.