### PR TITLE
Fix #1083: Machine and machine-like blocks don't conduct redstone anymore

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -244,6 +244,8 @@ neoForge {
             gameDirectory = project.file("build/gametest")
         }
     }
+
+    validateAccessTransformers = true
 }
 
 configurations {

--- a/src/main/java/aztech/modern_industrialization/MIBlock.java
+++ b/src/main/java/aztech/modern_industrialization/MIBlock.java
@@ -55,6 +55,7 @@ import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.MapColor;
@@ -82,17 +83,17 @@ public class MIBlock {
 
     // Bronze stuff
     public static final BlockDefinition<TrashCanBlock> TRASH_CAN = block("Automatic Trash Can", "trash_can",
-            BlockDefinitionParams.defaultStone().withBlockConstructor(TrashCanBlock::new).destroyTime(6.0f).explosionResistance(1200))
+            BlockDefinitionParams.defaultStone().withBlockConstructor(TrashCanBlock::new).destroyTime(6.0f).explosionResistance(1200).dontConductRedstone())
             .withBlockRegistrationEvent(TrashCanBlock::onRegister);
 
     // Other
-    public static final BlockDefinition<Block> BASIC_MACHINE_HULL = block("Basic Machine Hull", MIBlockKeys.BASIC_MACHINE_HULL.location().getPath());
-    public static final BlockDefinition<Block> ADVANCED_MACHINE_HULL = block("Advanced Machine Hull", MIBlockKeys.ADVANCED_MACHINE_HULL.location().getPath());
-    public static final BlockDefinition<Block> TURBO_MACHINE_HULL = block("Turbo Machine Hull", MIBlockKeys.TURBO_MACHINE_HULL.location().getPath());
-    public static final BlockDefinition<Block> HIGHLY_ADVANCED_MACHINE_HULL = block("Highly Advanced Machine Hull", MIBlockKeys.HIGHLY_ADVANCED_MACHINE_HULL.location().getPath());
-    public static final BlockDefinition<Block> QUANTUM_MACHINE_HULL = block("Quantum Machine Hull", MIBlockKeys.QUANTUM_MACHINE_HULL.location().getPath(), BlockDefinitionParams.defaultStone().explosionResistance(6000f));
+    public static final BlockDefinition<Block> BASIC_MACHINE_HULL = nonConductorBlock("Basic Machine Hull", MIBlockKeys.BASIC_MACHINE_HULL.location().getPath());
+    public static final BlockDefinition<Block> ADVANCED_MACHINE_HULL = nonConductorBlock("Advanced Machine Hull", MIBlockKeys.ADVANCED_MACHINE_HULL.location().getPath());
+    public static final BlockDefinition<Block> TURBO_MACHINE_HULL = nonConductorBlock("Turbo Machine Hull", MIBlockKeys.TURBO_MACHINE_HULL.location().getPath());
+    public static final BlockDefinition<Block> HIGHLY_ADVANCED_MACHINE_HULL = nonConductorBlock("Highly Advanced Machine Hull", MIBlockKeys.HIGHLY_ADVANCED_MACHINE_HULL.location().getPath());
+    public static final BlockDefinition<Block> QUANTUM_MACHINE_HULL = block("Quantum Machine Hull", MIBlockKeys.QUANTUM_MACHINE_HULL.location().getPath(), BlockDefinitionParams.defaultStone().explosionResistance(6000f).dontConductRedstone());
 
-    public static final BlockDefinition<Block> FUSION_CHAMBER = block("Fusion Chamber", "fusion_chamber");
+    public static final BlockDefinition<Block> FUSION_CHAMBER = nonConductorBlock("Fusion Chamber", "fusion_chamber");
     public static final BlockDefinition<Block> INDUSTRIAL_TNT = blockExplosive("Industrial TNT", "industrial_tnt");
     public static final BlockDefinition<Block> NUKE = blockExplosive("Nuke", "nuke");
 
@@ -128,7 +129,7 @@ public class MIBlock {
 
 
     public static final BlockDefinition<CreativeStorageUnitBlock> CREATIVE_STORAGE_UNIT = block("Creative Storage Unit",
-            "creative_storage_unit", BlockDefinitionParams.defaultStone().withBlockConstructor(CreativeStorageUnitBlock::new));
+            "creative_storage_unit", BlockDefinitionParams.defaultStone().withBlockConstructor(CreativeStorageUnitBlock::new).dontConductRedstone());
 
     // Materials
     public static final BlockDefinition<Block> BLOCK_FIRE_CLAY_BRICKS = block("Fire Clay Bricks", "fire_clay_bricks",
@@ -155,6 +156,10 @@ public class MIBlock {
 
     public static BlockDefinition<Block> block(String englishName, String id) {
         return MIBlock.block(englishName, id, BlockDefinitionParams.defaultStone());
+    }
+
+    public static BlockDefinition<Block> nonConductorBlock(String englishName, String id) {
+        return MIBlock.block(englishName, id, BlockDefinitionParams.defaultStone().dontConductRedstone());
     }
 
     public static BlockDefinition<Block> blockExplosive(String englishName, String id) {
@@ -309,6 +314,16 @@ public class MIBlock {
         // Bouncers to inner properties
         public BlockDefinitionParams<T> isValidSpawn(BlockBehaviour.StateArgumentPredicate<EntityType<?>> isValidSpawn) {
             this.props.isValidSpawn(isValidSpawn);
+            return this;
+        }
+
+        public BlockDefinitionParams<T> dontConductRedstone() {
+            this.props.isRedstoneConductor(Blocks::never);
+            return this;
+        }
+
+        public BlockDefinitionParams<T> isRedstoneConductor(BlockBehaviour.StatePredicate isRedstoneConductor) {
+            this.props.isRedstoneConductor(isRedstoneConductor);
             return this;
         }
 

--- a/src/main/java/aztech/modern_industrialization/blocks/storage/barrel/BarrelBlock.java
+++ b/src/main/java/aztech/modern_industrialization/blocks/storage/barrel/BarrelBlock.java
@@ -37,6 +37,7 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.MapColor;
@@ -47,7 +48,8 @@ import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
 public class BarrelBlock extends AbstractStorageBlock<ItemVariant> implements EntityBlock {
 
     public BarrelBlock(EntityBlock factory, StorageBehaviour<ItemVariant> behaviour) {
-        super(BlockBehaviour.Properties.of().mapColor(MapColor.METAL).destroyTime(4.0f).isValidSpawn(MobSpawning.NO_SPAWN), factory, behaviour);
+        super(BlockBehaviour.Properties.of().mapColor(MapColor.METAL).destroyTime(4.0f).isValidSpawn(MobSpawning.NO_SPAWN)
+                .isRedstoneConductor(Blocks::never), factory, behaviour);
     }
 
     private static boolean useBlock(BlockHitResult hitResult, InteractionHand hand, Player player, Level world) {

--- a/src/main/java/aztech/modern_industrialization/blocks/storage/tank/TankBlock.java
+++ b/src/main/java/aztech/modern_industrialization/blocks/storage/tank/TankBlock.java
@@ -34,6 +34,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
@@ -43,7 +44,8 @@ import net.minecraft.world.phys.BlockHitResult;
 public class TankBlock extends AbstractStorageBlock<FluidVariant> implements EntityBlock {
 
     public TankBlock(EntityBlock factory, StorageBehaviour<FluidVariant> behaviour) {
-        super(BlockBehaviour.Properties.of().mapColor(MapColor.METAL).destroyTime(4.0f).noOcclusion().isValidSpawn(MobSpawning.NO_SPAWN), factory,
+        super(BlockBehaviour.Properties.of().mapColor(MapColor.METAL).destroyTime(4.0f).noOcclusion().isValidSpawn(MobSpawning.NO_SPAWN)
+                .isRedstoneConductor(Blocks::never), factory,
                 behaviour);
     }
 

--- a/src/main/java/aztech/modern_industrialization/machines/init/MachineRegistrationHelper.java
+++ b/src/main/java/aztech/modern_industrialization/machines/init/MachineRegistrationHelper.java
@@ -41,6 +41,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -68,7 +69,8 @@ public class MachineRegistrationHelper {
                         .withModel((block, gen) -> {
                             // Model generation is handled in the model provider already.
                         })
-                        .isValidSpawn(MobSpawning.NO_SPAWN));
+                        .isValidSpawn(MobSpawning.NO_SPAWN)
+                        .isRedstoneConductor(Blocks::never));
 
         return MIRegistries.BLOCK_ENTITIES.register(id, () -> {
             Block block = blockDefinition.asBlock();

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -5,6 +5,10 @@ public-f net.minecraft.client.gui.components.AbstractWidget render(Lnet/minecraf
 # Used for menu interactions
 public net.minecraft.world.inventory.AbstractContainerMenu createCarriedSlotAccess()Lnet/minecraft/world/entity/SlotAccess;
 
+# Used for block state properties
+# TODO: PR to NeoForge
+public net.minecraft.world.level.block.Blocks never(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Z
+
 # Used for ore registration
 public net.minecraft.data.worldgen.placement.OrePlacements commonOrePlacement(ILnet/minecraft/world/level/levelgen/placement/PlacementModifier;)Ljava/util/List;
 


### PR DESCRIPTION
Notably, this means that level emitters will only power the machine that they are targeting, but not adjacent ones.