### PR TITLE
Use new maven repository for KubeJS & FTB mods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,14 +100,6 @@ repositories {
         }
     }
     maven {
-        url "https://maven.saps.dev/minecraft"
-        content {
-            includeGroup "dev.latvian.apps"
-            includeGroup "dev.latvian.mods"
-            includeGroup "dev.ftb.mods"
-        }
-    }
-    maven {
         url "https://maven.ftb.dev/releases"
         content {
             includeGroup "dev.ftb.mods"
@@ -135,9 +127,9 @@ repositories {
             includeGroup "me.luligabi"
         }
     }
-    // For FTBTeams/FTBQuests
+    // For KubeJS & FTBTeams/FTBQuests
     maven {
-        url "https://maven.saps.dev/minecraft"
+        url "https://maven.latvian.dev/releases"
         content {
             includeGroup "dev.latvian.mods"
             includeGroup "dev.ftb.mods"


### PR DESCRIPTION
Not sure as to the reason why, but it appears KubeJS and the FTB mods were removed from saps. Swapping to Latvian's repo fixes not being able to resolve the dependencies