### PR TITLE
Allow custom multiblocks to have a custom CrafterComponent

### DIFF
--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/AbstractCraftingMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/AbstractCraftingMultiblockBlockEntity.java
@@ -94,17 +94,17 @@ public abstract class AbstractCraftingMultiblockBlockEntity extends MultiblockMa
             boolean newActive = false;
 
             if (operatingState == OperatingState.TRYING_TO_RESUME) {
-                if (crafter.tryContinueRecipe()) {
+                if (getCrafterComponent().tryContinueRecipe()) {
                     operatingState = OperatingState.NORMAL_OPERATION;
                 }
             }
 
             if (operatingState == OperatingState.NORMAL_OPERATION) {
-                if (crafter.tickRecipe()) {
+                if (getCrafterComponent().tickRecipe()) {
                     newActive = true;
                 }
             } else {
-                crafter.decreaseEfficiencyTicks();
+                getCrafterComponent().decreaseEfficiencyTicks();
             }
 
             isActive.updateActive(newActive, this);

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/AbstractCraftingMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/AbstractCraftingMultiblockBlockEntity.java
@@ -94,17 +94,17 @@ public abstract class AbstractCraftingMultiblockBlockEntity extends MultiblockMa
             boolean newActive = false;
 
             if (operatingState == OperatingState.TRYING_TO_RESUME) {
-                if (getCrafterComponent().tryContinueRecipe()) {
+                if (crafter.tryContinueRecipe()) {
                     operatingState = OperatingState.NORMAL_OPERATION;
                 }
             }
 
             if (operatingState == OperatingState.NORMAL_OPERATION) {
-                if (getCrafterComponent().tickRecipe()) {
+                if (crafter.tickRecipe()) {
                     newActive = true;
                 }
             } else {
-                getCrafterComponent().decreaseEfficiencyTicks();
+                crafter.decreaseEfficiencyTicks();
             }
 
             isActive.updateActive(newActive, this);

--- a/src/main/java/aztech/modern_industrialization/machines/components/CrafterComponent.java
+++ b/src/main/java/aztech/modern_industrialization/machines/components/CrafterComponent.java
@@ -106,6 +106,9 @@ public class CrafterComponent implements IComponent.ServerOnly, CrafterAccess {
             return false;
         }
 
+        default void onCraft() {
+        }
+
         // can't use getWorld() or the remapping will fail
         ServerLevel getCrafterWorld();
 
@@ -184,9 +187,6 @@ public class CrafterComponent implements IComponent.ServerOnly, CrafterAccess {
         efficiencyTicks = Math.min(efficiencyTicks + increment, maxEfficiencyTicks);
     }
 
-    protected void onCraft() {
-    }
-
     @Override
     public long getCurrentRecipeEu() {
         Preconditions.checkArgument(hasActiveRecipe());
@@ -243,7 +243,7 @@ public class CrafterComponent implements IComponent.ServerOnly, CrafterAccess {
                     clearLocks();
                     usedEnergy = 0;
                     finishedRecipe = true;
-                    onCraft();
+                    behavior.onCraft();
                 }
             } else if (behavior.isOverdriving()) {
                 eu = activeRecipe.value().conditionsMatch(conditionContext) ? behavior.consumeEu(recipeMaxEu, ACT) : 0;

--- a/src/main/java/aztech/modern_industrialization/machines/components/CrafterComponent.java
+++ b/src/main/java/aztech/modern_industrialization/machines/components/CrafterComponent.java
@@ -184,6 +184,9 @@ public class CrafterComponent implements IComponent.ServerOnly, CrafterAccess {
         efficiencyTicks = Math.min(efficiencyTicks + increment, maxEfficiencyTicks);
     }
 
+    protected void onCraft() {
+    }
+
     @Override
     public long getCurrentRecipeEu() {
         Preconditions.checkArgument(hasActiveRecipe());
@@ -240,6 +243,7 @@ public class CrafterComponent implements IComponent.ServerOnly, CrafterAccess {
                     clearLocks();
                     usedEnergy = 0;
                     finishedRecipe = true;
+                    onCraft();
                 }
             } else if (behavior.isOverdriving()) {
                 eu = activeRecipe.value().conditionsMatch(conditionContext) ? behavior.consumeEu(recipeMaxEu, ACT) : 0;


### PR DESCRIPTION
# Problem

`AbstractCraftingMultiblockBlockEntity` implements `CrafterComponentHolder`, but directly accesses `crafter` instead of calling `getCrafterComponent` on `tick`, meaning any implementing classes are unable to have a custom `CrafterComponent`. 

# Solution

All direct accesses to `crafter` on `tick` are replaced by `getCrafterComponent`. This PR also includes a new method called `onCraft` that allows custom `CrafterComponent`s to detect when a recipe is completed without overriding/mixin injecting `tickRecipe`.

# Use case

Imagine a machine that alters the non-consumed input stack in some way (i.e. one of its data components' value). If said way is not recipe dependent, `CrafterComponent` is the most sensible place to modify it.