### PR TITLE
Add registeredCondition to ProcessConditionHelper

### DIFF
--- a/docs/ADDING_RECIPES.md
+++ b/docs/ADDING_RECIPES.md
@@ -90,6 +90,24 @@ ServerEvents.recipes(event => {
 });
 ```
 
+## Registered process conditions
+If a process condition doesn't have direct KubeJS support (like from an addon mod), you can manually write its parameters using `registeredCondition(JsonObject)`: 
+
+```js
+// Manually adding a dimension condition - of course, this is just an example and you don't have a reason to actually do it this way.
+ServerEvents.recipes(event => {
+    event.recipes.modern_industrialization.compressor(2, 200)
+        .itemIn("dirt")
+        .itemOut("diamond")
+        // Use custom condition defined above
+        .registeredCondition({
+          "modern_industrialization:dimension": {
+            "dimension": "minecraft:the_nether"
+          }
+        })
+});
+```
+
 ## Adding multiblock slots
 Multiblock machines always have an unlimited number of input and output slots
 (provided the recipe type allows the relevant input/output types).

--- a/docs/ADDING_RECIPES.md
+++ b/docs/ADDING_RECIPES.md
@@ -99,7 +99,6 @@ ServerEvents.recipes(event => {
     event.recipes.modern_industrialization.compressor(2, 200)
         .itemIn("dirt")
         .itemOut("diamond")
-        // Use custom condition defined above
         .registeredCondition({
           "modern_industrialization:dimension": {
             "dimension": "minecraft:the_nether"

--- a/src/main/java/aztech/modern_industrialization/compat/kubejs/recipe/ProcessConditionHelper.java
+++ b/src/main/java/aztech/modern_industrialization/compat/kubejs/recipe/ProcessConditionHelper.java
@@ -23,17 +23,21 @@
  */
 package aztech.modern_industrialization.compat.kubejs.recipe;
 
-import aztech.modern_industrialization.machines.recipe.condition.AdjacentBlockProcessCondition;
-import aztech.modern_industrialization.machines.recipe.condition.BiomeProcessCondition;
-import aztech.modern_industrialization.machines.recipe.condition.CustomProcessCondition;
-import aztech.modern_industrialization.machines.recipe.condition.DimensionProcessCondition;
-import aztech.modern_industrialization.machines.recipe.condition.MachineProcessCondition;
+import aztech.modern_industrialization.machines.recipe.condition.*;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.mojang.datafixers.util.Either;
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.JsonOps;
+import com.mojang.serialization.MapCodec;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.block.Block;
+
+import java.util.Map;
 
 public interface ProcessConditionHelper {
     ProcessConditionHelper processCondition(MachineProcessCondition condition);
@@ -56,5 +60,36 @@ public interface ProcessConditionHelper {
 
     default ProcessConditionHelper customCondition(String id) {
         return processCondition(new CustomProcessCondition(id));
+    }
+
+    default ProcessConditionHelper registeredCondition(JsonElement condition) {
+        if (!condition.isJsonObject()) {
+            throw new IllegalArgumentException("Parameter must be a JsonObject");
+        }
+
+        JsonObject obj = condition.getAsJsonObject();
+        if (obj.size() != 1) {
+            throw new IllegalArgumentException("Expected only condition ID");
+        }
+
+        Map.Entry<String, JsonElement> entry = obj.entrySet().iterator().next();
+        String idString = entry.getKey();
+
+        ResourceLocation id = ResourceLocation.tryParse(idString);
+        if (id == null) {
+            throw new IllegalArgumentException(String.format("'%s' is not registered at MachineProcessConditions. Perhaps you meant to use a customCondition?", idString));
+        }
+
+        MapCodec<? extends MachineProcessCondition> codec = MachineProcessConditions.getCodec(id);
+        if (codec == null) {
+            throw new IllegalArgumentException("'%s' doesn't have a registered codec!".formatted(idString));
+        }
+
+        DataResult<MachineProcessCondition> result = codec.codec().decode(JsonOps.INSTANCE, entry.getValue())
+                .map(Pair::getFirst);
+
+        return processCondition(result.getOrThrow(p -> {
+            throw new IllegalArgumentException("Couldn't parse '%s': %s".formatted(idString, p));
+        }));
     }
 }

--- a/src/main/java/aztech/modern_industrialization/compat/kubejs/recipe/ProcessConditionHelper.java
+++ b/src/main/java/aztech/modern_industrialization/compat/kubejs/recipe/ProcessConditionHelper.java
@@ -31,13 +31,12 @@ import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.JsonOps;
 import com.mojang.serialization.MapCodec;
+import java.util.Map;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.block.Block;
-
-import java.util.Map;
 
 public interface ProcessConditionHelper {
     ProcessConditionHelper processCondition(MachineProcessCondition condition);
@@ -77,7 +76,8 @@ public interface ProcessConditionHelper {
 
         ResourceLocation id = ResourceLocation.tryParse(idString);
         if (id == null) {
-            throw new IllegalArgumentException(String.format("'%s' is not registered at MachineProcessConditions. Perhaps you meant to use a customCondition?", idString));
+            throw new IllegalArgumentException(
+                    String.format("'%s' is not registered at MachineProcessConditions. Perhaps you meant to use a customCondition?", idString));
         }
 
         MapCodec<? extends MachineProcessCondition> codec = MachineProcessConditions.getCodec(id);


### PR DESCRIPTION
Allows registered conditions to be explicitly passed onto recipes without helper methods. Example:

```
ServerEvents.recipes(event => {
    event.recipes.modern_industrialization.blast_furnace(128, 100)
        // add all the inputs and outputs:
        .itemIn("64x #minecraft:logs_that_burn")
        .itemOut("64x minecraft:charcoal")
        .fluidIn("1000x modern_industrialization:oxygen")
        .fluidOut("5000x modern_industrialization:creosote")
        .registeredCondition({
            "modern_industrialization:dimension": {
                "dimension": "minecraft:the_nether"
            }
        })          
})

```

Have a recipe type in my upcoming addon that almost always includes a process condition and it'd be a bummer to maintain KJS support just for that 😅