### PR TITLE
Allow for EnergyHatch with custom namespace

### DIFF
--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/EnergyHatch.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/EnergyHatch.java
@@ -43,8 +43,8 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 
 public class EnergyHatch extends HatchBlockEntity implements EnergyComponentHolder, CableTierHolder {
 
-    public EnergyHatch(BEP bep, String name, boolean input, CableTier tier) {
-        super(bep, new MachineGuiParameters.Builder(name, false).build(), new OrientationComponent.Params(!input, false, false));
+    public EnergyHatch(BEP bep, MachineGuiParameters guiParams, boolean input, CableTier tier) {
+        super(bep, guiParams, new OrientationComponent.Params(!input, false, false));
 
         this.input = input;
         this.tier = tier;

--- a/src/main/java/aztech/modern_industrialization/machines/init/MultiblockHatches.java
+++ b/src/main/java/aztech/modern_industrialization/machines/init/MultiblockHatches.java
@@ -125,7 +125,8 @@ public class MultiblockHatches {
             boolean input = iter == 0;
             String machine = tier.name + "_energy_" + (input ? "input" : "output") + "_hatch";
             String englishName = tier.shortEnglishName + " Energy" + (input ? " Input" : " Output") + " Hatch";
-            MachineRegistrationHelper.registerMachine(englishName, machine, bet -> new EnergyHatch(bet, machine, input, tier),
+            MachineRegistrationHelper.registerMachine(englishName, machine,
+                    bet -> new EnergyHatch(bet, new MachineGuiParameters.Builder(machine, false).build(), input, tier),
                     EnergyHatch::registerEnergyApi);
             MachineRegistrationHelper.addMachineModel(machine, "hatch_energy", tier.casing, true, false, true, false);
         }


### PR DESCRIPTION
I think this got missed in that PR I did a while ago...

Makes it so EnergyHatch's constructor is consistent with ItemHatch and FluidHatch so addons can add custom EnergyHatches with their namespace too.