### PR TITLE
Allow for custom hatch types

### DIFF
--- a/src/main/java/aztech/modern_industrialization/compat/kubejs/machine/ShapeTemplateHelper.java
+++ b/src/main/java/aztech/modern_industrialization/compat/kubejs/machine/ShapeTemplateHelper.java
@@ -25,7 +25,7 @@ package aztech.modern_industrialization.compat.kubejs.machine;
 
 import aztech.modern_industrialization.machines.models.MachineCasings;
 import aztech.modern_industrialization.machines.multiblocks.HatchFlags;
-import aztech.modern_industrialization.machines.multiblocks.HatchType;
+import aztech.modern_industrialization.machines.multiblocks.HatchTypes;
 import aztech.modern_industrialization.machines.multiblocks.ShapeTemplate;
 import aztech.modern_industrialization.machines.multiblocks.SimpleMember;
 import net.minecraft.resources.ResourceLocation;
@@ -50,15 +50,7 @@ public interface ShapeTemplateHelper {
     default HatchFlags hatchOf(String... hatches) {
         var builder = new HatchFlags.Builder();
         for (String hatch : hatches) {
-            switch (hatch) {
-            case "item_input" -> builder.with(HatchType.ITEM_INPUT);
-            case "item_output" -> builder.with(HatchType.ITEM_OUTPUT);
-            case "fluid_input" -> builder.with(HatchType.FLUID_INPUT);
-            case "fluid_output" -> builder.with(HatchType.FLUID_OUTPUT);
-            case "energy_input" -> builder.with(HatchType.ENERGY_INPUT);
-            case "energy_output" -> builder.with(HatchType.ENERGY_OUTPUT);
-            default -> throw new IllegalArgumentException("Unsupported hatch type: " + hatch);
-            }
+            builder.with(HatchTypes.get(hatch));
         }
         return builder.build();
     }

--- a/src/main/java/aztech/modern_industrialization/guidebook/MultiblockShapeCompiler.java
+++ b/src/main/java/aztech/modern_industrialization/guidebook/MultiblockShapeCompiler.java
@@ -25,7 +25,7 @@ package aztech.modern_industrialization.guidebook;
 
 import aztech.modern_industrialization.MIText;
 import aztech.modern_industrialization.machines.MachineBlock;
-import aztech.modern_industrialization.machines.multiblocks.HatchType;
+import aztech.modern_industrialization.machines.multiblocks.HatchTypes;
 import aztech.modern_industrialization.machines.multiblocks.MultiblockMachineBlockEntity;
 import guideme.color.SymbolicColor;
 import guideme.compiler.PageCompiler;
@@ -83,7 +83,7 @@ public class MultiblockShapeCompiler implements SceneElementTagCompiler {
 
             tooltipLines.add(MIText.AcceptsHatches.text());
             var flags = entry.getValue();
-            for (var type : HatchType.values()) {
+            for (var type : HatchTypes.values()) {
                 if (flags.allows(type)) {
                     tooltipLines.add(Component.literal("- ").append(type.description()));
                 }

--- a/src/main/java/aztech/modern_industrialization/guidebook/MultiblockShapeCompiler.java
+++ b/src/main/java/aztech/modern_industrialization/guidebook/MultiblockShapeCompiler.java
@@ -25,7 +25,6 @@ package aztech.modern_industrialization.guidebook;
 
 import aztech.modern_industrialization.MIText;
 import aztech.modern_industrialization.machines.MachineBlock;
-import aztech.modern_industrialization.machines.multiblocks.HatchTypes;
 import aztech.modern_industrialization.machines.multiblocks.MultiblockMachineBlockEntity;
 import guideme.color.SymbolicColor;
 import guideme.compiler.PageCompiler;
@@ -83,10 +82,8 @@ public class MultiblockShapeCompiler implements SceneElementTagCompiler {
 
             tooltipLines.add(MIText.AcceptsHatches.text());
             var flags = entry.getValue();
-            for (var type : HatchTypes.values()) {
-                if (flags.allows(type)) {
-                    tooltipLines.add(Component.literal("- ").append(type.description()));
-                }
+            for (var type : flags.values()) {
+                tooltipLines.add(Component.literal("- ").append(type.description()));
             }
             annotation.setTooltip(new TextTooltip(tooltipLines));
             scene.addAnnotation(annotation);

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/EnergyHatch.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/EnergyHatch.java
@@ -38,6 +38,7 @@ import aztech.modern_industrialization.machines.guicomponents.EnergyBar;
 import aztech.modern_industrialization.machines.helper.EnergyHelper;
 import aztech.modern_industrialization.machines.multiblocks.HatchBlockEntity;
 import aztech.modern_industrialization.machines.multiblocks.HatchType;
+import aztech.modern_industrialization.machines.multiblocks.HatchTypes;
 import java.util.List;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 
@@ -67,7 +68,7 @@ public class EnergyHatch extends HatchBlockEntity implements EnergyComponentHold
 
     @Override
     public HatchType getHatchType() {
-        return input ? HatchType.ENERGY_INPUT : HatchType.ENERGY_OUTPUT;
+        return input ? HatchTypes.ENERGY_INPUT : HatchTypes.ENERGY_OUTPUT;
     }
 
     @Override

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/FluidHatch.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/FluidHatch.java
@@ -31,6 +31,7 @@ import aztech.modern_industrialization.machines.gui.MachineGuiParameters;
 import aztech.modern_industrialization.machines.guicomponents.AutoExtract;
 import aztech.modern_industrialization.machines.multiblocks.HatchBlockEntity;
 import aztech.modern_industrialization.machines.multiblocks.HatchType;
+import aztech.modern_industrialization.machines.multiblocks.HatchTypes;
 import java.util.List;
 
 public class FluidHatch extends HatchBlockEntity {
@@ -51,7 +52,7 @@ public class FluidHatch extends HatchBlockEntity {
 
     @Override
     public HatchType getHatchType() {
-        return input ? HatchType.FLUID_INPUT : HatchType.FLUID_OUTPUT;
+        return input ? HatchTypes.FLUID_INPUT : HatchTypes.FLUID_OUTPUT;
     }
 
     @Override

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/ItemHatch.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/ItemHatch.java
@@ -31,6 +31,7 @@ import aztech.modern_industrialization.machines.gui.MachineGuiParameters;
 import aztech.modern_industrialization.machines.guicomponents.AutoExtract;
 import aztech.modern_industrialization.machines.multiblocks.HatchBlockEntity;
 import aztech.modern_industrialization.machines.multiblocks.HatchType;
+import aztech.modern_industrialization.machines.multiblocks.HatchTypes;
 import java.util.List;
 
 public class ItemHatch extends HatchBlockEntity {
@@ -51,7 +52,7 @@ public class ItemHatch extends HatchBlockEntity {
 
     @Override
     public HatchType getHatchType() {
-        return input ? HatchType.ITEM_INPUT : HatchType.ITEM_OUTPUT;
+        return input ? HatchTypes.ITEM_INPUT : HatchTypes.ITEM_OUTPUT;
     }
 
     @Override

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/LargeTankHatch.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/LargeTankHatch.java
@@ -35,6 +35,7 @@ import aztech.modern_industrialization.machines.components.OrientationComponent;
 import aztech.modern_industrialization.machines.gui.MachineGuiParameters;
 import aztech.modern_industrialization.machines.multiblocks.HatchBlockEntity;
 import aztech.modern_industrialization.machines.multiblocks.HatchType;
+import aztech.modern_industrialization.machines.multiblocks.HatchTypes;
 import java.util.List;
 import net.minecraft.ChatFormatting;
 import net.minecraft.server.level.ServerPlayer;
@@ -70,7 +71,7 @@ public class LargeTankHatch extends HatchBlockEntity implements FluidStorageComp
 
     @Override
     public HatchType getHatchType() {
-        return HatchType.LARGE_TANK;
+        return HatchTypes.LARGE_TANK;
     }
 
     @Override

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/NuclearHatch.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/NuclearHatch.java
@@ -37,6 +37,7 @@ import aztech.modern_industrialization.machines.gui.MachineGuiParameters;
 import aztech.modern_industrialization.machines.guicomponents.TemperatureBar;
 import aztech.modern_industrialization.machines.multiblocks.HatchBlockEntity;
 import aztech.modern_industrialization.machines.multiblocks.HatchType;
+import aztech.modern_industrialization.machines.multiblocks.HatchTypes;
 import aztech.modern_industrialization.nuclear.*;
 import aztech.modern_industrialization.thirdparty.fabrictransfer.api.fluid.FluidVariant;
 import aztech.modern_industrialization.thirdparty.fabrictransfer.api.item.ItemVariant;
@@ -98,7 +99,7 @@ public class NuclearHatch extends HatchBlockEntity implements INuclearTile {
 
     @Override
     public HatchType getHatchType() {
-        return isFluid ? HatchType.NUCLEAR_FLUID : HatchType.NUCLEAR_ITEM;
+        return isFluid ? HatchTypes.NUCLEAR_FLUID : HatchTypes.NUCLEAR_ITEM;
     }
 
     @Override

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/DistillationTowerBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/DistillationTowerBlockEntity.java
@@ -114,8 +114,8 @@ public class DistillationTowerBlockEntity extends AbstractElectricCraftingMultib
 
         SimpleMember casing = SimpleMember.forBlock(MIBlock.BLOCK_DEFINITIONS.get(MI.id("clean_stainless_steel_machine_casing")));
         SimpleMember pipe = SimpleMember.forBlock(MIBlock.BLOCK_DEFINITIONS.get(MI.id("stainless_steel_machine_casing_pipe")));
-        HatchFlags bottom = new HatchFlags.Builder().with(HatchType.ENERGY_INPUT, HatchType.FLUID_INPUT).build();
-        HatchFlags layer = new HatchFlags.Builder().with(HatchType.FLUID_OUTPUT).build();
+        HatchFlags bottom = new HatchFlags.Builder().with(HatchTypes.ENERGY_INPUT, HatchTypes.FLUID_INPUT).build();
+        HatchFlags layer = new HatchFlags.Builder().with(HatchTypes.FLUID_OUTPUT).build();
         for (int i = 0; i < MAX_HEIGHT; ++i) {
             ShapeTemplate.Builder builder = new ShapeTemplate.Builder(MachineCasings.CLEAN_STAINLESS_STEEL);
             for (int y = 0; y <= i + 1; ++y) {

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/ElectricBlastFurnaceBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/ElectricBlastFurnaceBlockEntity.java
@@ -23,7 +23,7 @@
  */
 package aztech.modern_industrialization.machines.blockentities.multiblocks;
 
-import static aztech.modern_industrialization.machines.multiblocks.HatchType.*;
+import static aztech.modern_industrialization.machines.multiblocks.HatchTypes.*;
 
 import aztech.modern_industrialization.MI;
 import aztech.modern_industrialization.MIBlock;

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/LargeTankMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/LargeTankMultiblockBlockEntity.java
@@ -109,7 +109,7 @@ public class LargeTankMultiblockBlockEntity extends MultiblockMachineBlockEntity
         ShapeTemplate.Builder templateBuilder = new ShapeTemplate.Builder(MachineCasings.STEEL);
         SimpleMember steelCasing = SimpleMember.forBlock(MIBlock.BLOCK_DEFINITIONS.get(MI.id("steel_machine_casing")));
         SimpleMember glass = SimpleMember.forBlock(() -> Blocks.GLASS);
-        HatchFlags hatchFlags = new HatchFlags.Builder().with(HatchType.LARGE_TANK).build();
+        HatchFlags hatchFlags = new HatchFlags.Builder().with(HatchTypes.LARGE_TANK).build();
 
         for (int x = -sizeX / 2; x <= sizeX / 2; x++) {
             for (int y = -1; y < sizeY - 1; y++) {

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/NuclearReactorMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/NuclearReactorMultiblockBlockEntity.java
@@ -200,7 +200,7 @@ public class NuclearReactorMultiblockBlockEntity extends MultiblockMachineBlockE
 
         SimpleMember casing = SimpleMember.forBlock(MIBlock.BLOCK_DEFINITIONS.get(MI.id("nuclear_casing")));
         SimpleMember pipe = SimpleMember.forBlock(MIBlock.BLOCK_DEFINITIONS.get(MI.id("nuclear_alloy_machine_casing_pipe")));
-        HatchFlags top = new HatchFlags.Builder().with(HatchType.NUCLEAR_FLUID, HatchType.NUCLEAR_ITEM).build();
+        HatchFlags top = new HatchFlags.Builder().with(HatchTypes.NUCLEAR_FLUID, HatchTypes.NUCLEAR_ITEM).build();
         for (int i = 0; i < 4; i++) {
             ShapeTemplate.Builder builder = new ShapeTemplate.Builder(MachineCasings.NUCLEAR);
             gridLayout[i] = new boolean[5 + 2 * i][5 + 2 * i];

--- a/src/main/java/aztech/modern_industrialization/machines/init/MultiblockMachines.java
+++ b/src/main/java/aztech/modern_industrialization/machines/init/MultiblockMachines.java
@@ -24,7 +24,7 @@
 package aztech.modern_industrialization.machines.init;
 
 import static aztech.modern_industrialization.machines.models.MachineCasings.CLEAN_STAINLESS_STEEL;
-import static aztech.modern_industrialization.machines.multiblocks.HatchType.*;
+import static aztech.modern_industrialization.machines.multiblocks.HatchTypes.*;
 
 import aztech.modern_industrialization.MI;
 import aztech.modern_industrialization.MIBlock;

--- a/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchFlags.java
+++ b/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchFlags.java
@@ -40,6 +40,10 @@ public class HatchFlags {
         return allowed.contains(type);
     }
 
+    public Set<HatchType> values() {
+        return allowed;
+    }
+
     public static class Builder {
         private final Set<HatchType> allowed = new HashSet<>();
 

--- a/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchFlags.java
+++ b/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchFlags.java
@@ -23,24 +23,28 @@
  */
 package aztech.modern_industrialization.machines.multiblocks;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 public class HatchFlags {
     public static final HatchFlags NO_HATCH = new Builder().build();
 
-    private final int flags;
+    private final Set<HatchType> allowed;
 
-    public HatchFlags(int flags) {
-        this.flags = flags;
+    public HatchFlags(Set<HatchType> allowed) {
+        this.allowed = Collections.unmodifiableSet(allowed);
     }
 
     public boolean allows(HatchType type) {
-        return (flags & (1 << type.getId())) > 0;
+        return allowed.contains(type);
     }
 
     public static class Builder {
-        private int flags = 0;
+        private final Set<HatchType> allowed = new HashSet<>();
 
         public Builder with(HatchType type) {
-            flags |= 1 << type.getId();
+            allowed.add(type);
             return this;
         }
 
@@ -53,7 +57,7 @@ public class HatchFlags {
         }
 
         public HatchFlags build() {
-            return new HatchFlags(flags);
+            return new HatchFlags(allowed);
         }
     }
 }

--- a/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchFlags.java
+++ b/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchFlags.java
@@ -23,7 +23,6 @@
  */
 package aztech.modern_industrialization.machines.multiblocks;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -33,7 +32,7 @@ public class HatchFlags {
     private final Set<HatchType> allowed;
 
     public HatchFlags(Set<HatchType> allowed) {
-        this.allowed = Collections.unmodifiableSet(allowed);
+        this.allowed = Set.copyOf(allowed);
     }
 
     public boolean allows(HatchType type) {

--- a/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchType.java
+++ b/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchType.java
@@ -25,14 +25,15 @@ package aztech.modern_industrialization.machines.multiblocks;
 
 import com.mojang.datafixers.util.Either;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 
 public class HatchType {
     private final ResourceLocation id;
-    private final Either<MutableComponent, ResourceLocation> descriptionOrBlockId;
+    private final Either<Component, ResourceLocation> descriptionOrBlockId;
 
-    HatchType(ResourceLocation id, MutableComponent description) {
+    HatchType(ResourceLocation id, Component description) {
         this.id = id;
         this.descriptionOrBlockId = Either.left(description);
     }
@@ -47,7 +48,7 @@ public class HatchType {
     }
 
     public MutableComponent description() {
-        return descriptionOrBlockId.map(text -> text, id -> BuiltInRegistries.BLOCK.get(id).getName());
+        return descriptionOrBlockId.map(Component::copy, id -> BuiltInRegistries.BLOCK.get(id).getName());
     }
 
     @Override

--- a/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchType.java
+++ b/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchType.java
@@ -23,42 +23,40 @@
  */
 package aztech.modern_industrialization.machines.multiblocks;
 
-import aztech.modern_industrialization.MI;
-import aztech.modern_industrialization.MIText;
 import com.mojang.datafixers.util.Either;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 
-public enum HatchType {
-    ITEM_INPUT(0, MIText.ItemInputHatch),
-    ITEM_OUTPUT(1, MIText.ItemOutputHatch),
-    FLUID_INPUT(2, MIText.FluidInputHatch),
-    FLUID_OUTPUT(3, MIText.FluidOutputHatch),
-    ENERGY_INPUT(4, MIText.EnergyInputHatch),
-    ENERGY_OUTPUT(5, MIText.EnergyOutputHatch),
-    NUCLEAR_ITEM(6, "nuclear_item_hatch"),
-    NUCLEAR_FLUID(7, "nuclear_fluid_hatch"),
-    LARGE_TANK(8, "large_tank_hatch");
+public class HatchType {
+    private final ResourceLocation id;
+    private final Either<MutableComponent, ResourceLocation> descriptionOrBlockId;
 
-    private final int id;
-    private final Either<MIText, ResourceLocation> descriptionOrBlockId;
-
-    HatchType(int id, MIText description) {
+    HatchType(ResourceLocation id, MutableComponent description) {
         this.id = id;
         this.descriptionOrBlockId = Either.left(description);
     }
 
-    HatchType(int id, String blockId) {
+    HatchType(ResourceLocation id, ResourceLocation blockId) {
         this.id = id;
-        this.descriptionOrBlockId = Either.right(MI.id(blockId));
+        this.descriptionOrBlockId = Either.right(blockId);
     }
 
-    public int getId() {
+    public ResourceLocation id() {
         return id;
     }
 
     public MutableComponent description() {
-        return descriptionOrBlockId.map(MIText::text, id -> BuiltInRegistries.BLOCK.get(id).getName());
+        return descriptionOrBlockId.map(text -> text, id -> BuiltInRegistries.BLOCK.get(id).getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof HatchType other && id.equals(other.id);
     }
 }

--- a/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchType.java
+++ b/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchType.java
@@ -29,7 +29,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 
-public class HatchType {
+public final class HatchType {
     private final ResourceLocation id;
     private final Either<Component, ResourceLocation> descriptionOrBlockId;
 

--- a/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchTypes.java
+++ b/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchTypes.java
@@ -57,6 +57,9 @@ public class HatchTypes {
         return register(id, description.text());
     }
 
+    /**
+     * The block id corresponds to the user-facing description of the hatch type.
+     */
     public static HatchType register(ResourceLocation id, ResourceLocation blockId) {
         if (registeredHatches.containsKey(id)) {
             throw new IllegalArgumentException("Duplicate hatch type definition: " + id);

--- a/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchTypes.java
+++ b/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchTypes.java
@@ -1,0 +1,85 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Azercoco & Technici4n
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package aztech.modern_industrialization.machines.multiblocks;
+
+import aztech.modern_industrialization.MI;
+import aztech.modern_industrialization.MIText;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.resources.ResourceLocation;
+
+public class HatchTypes {
+    private static final Map<ResourceLocation, HatchType> registeredHatches = new HashMap<>();
+
+    public static final HatchType ITEM_INPUT = create(MI.id("item_input"), MIText.ItemInputHatch);
+    public static final HatchType ITEM_OUTPUT = create(MI.id("item_output"), MIText.ItemOutputHatch);
+    public static final HatchType FLUID_INPUT = create(MI.id("fluid_input"), MIText.FluidInputHatch);
+    public static final HatchType FLUID_OUTPUT = create(MI.id("fluid_output"), MIText.FluidOutputHatch);
+    public static final HatchType ENERGY_INPUT = create(MI.id("energy_input"), MIText.EnergyInputHatch);
+    public static final HatchType ENERGY_OUTPUT = create(MI.id("energy_output"), MIText.EnergyOutputHatch);
+    public static final HatchType NUCLEAR_ITEM = create(MI.id("nuclear_item"), MI.id("nuclear_item_hatch"));
+    public static final HatchType NUCLEAR_FLUID = create(MI.id("nuclear_fluid"), MI.id("nuclear_fluid_hatch"));
+    public static final HatchType LARGE_TANK = create(MI.id("large_tank"), MI.id("large_tank_hatch"));
+
+    public static HatchType create(ResourceLocation id, MutableComponent description) {
+        if (registeredHatches.containsKey(id)) {
+            throw new IllegalArgumentException("Duplicate hatch type definition: " + id);
+        }
+        var type = new HatchType(id, description);
+        registeredHatches.put(id, type);
+        return type;
+    }
+
+    public static HatchType create(ResourceLocation id, MIText description) {
+        return create(id, description.text());
+    }
+
+    public static HatchType create(ResourceLocation id, ResourceLocation blockId) {
+        if (registeredHatches.containsKey(id)) {
+            throw new IllegalArgumentException("Duplicate hatch type definition: " + id);
+        }
+        var type = new HatchType(id, blockId);
+        registeredHatches.put(id, type);
+        return type;
+    }
+
+    public static HatchType get(ResourceLocation id) {
+        var type = registeredHatches.get(id);
+        if (type != null) {
+            return type;
+        } else {
+            throw new IllegalArgumentException("Hatch type \"" + id + "\" does not exist.");
+        }
+    }
+
+    public static HatchType get(String name) {
+        return get(ResourceLocation.isValidPath(name) ? MI.id(name) : ResourceLocation.parse(name));
+    }
+
+    public static Collection<HatchType> values() {
+        return registeredHatches.values();
+    }
+}

--- a/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchTypes.java
+++ b/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchTypes.java
@@ -34,17 +34,17 @@ import net.minecraft.resources.ResourceLocation;
 public class HatchTypes {
     private static final Map<ResourceLocation, HatchType> registeredHatches = new HashMap<>();
 
-    public static final HatchType ITEM_INPUT = create(MI.id("item_input"), MIText.ItemInputHatch);
-    public static final HatchType ITEM_OUTPUT = create(MI.id("item_output"), MIText.ItemOutputHatch);
-    public static final HatchType FLUID_INPUT = create(MI.id("fluid_input"), MIText.FluidInputHatch);
-    public static final HatchType FLUID_OUTPUT = create(MI.id("fluid_output"), MIText.FluidOutputHatch);
-    public static final HatchType ENERGY_INPUT = create(MI.id("energy_input"), MIText.EnergyInputHatch);
-    public static final HatchType ENERGY_OUTPUT = create(MI.id("energy_output"), MIText.EnergyOutputHatch);
-    public static final HatchType NUCLEAR_ITEM = create(MI.id("nuclear_item"), MI.id("nuclear_item_hatch"));
-    public static final HatchType NUCLEAR_FLUID = create(MI.id("nuclear_fluid"), MI.id("nuclear_fluid_hatch"));
-    public static final HatchType LARGE_TANK = create(MI.id("large_tank"), MI.id("large_tank_hatch"));
+    public static final HatchType ITEM_INPUT = register(MI.id("item_input"), MIText.ItemInputHatch);
+    public static final HatchType ITEM_OUTPUT = register(MI.id("item_output"), MIText.ItemOutputHatch);
+    public static final HatchType FLUID_INPUT = register(MI.id("fluid_input"), MIText.FluidInputHatch);
+    public static final HatchType FLUID_OUTPUT = register(MI.id("fluid_output"), MIText.FluidOutputHatch);
+    public static final HatchType ENERGY_INPUT = register(MI.id("energy_input"), MIText.EnergyInputHatch);
+    public static final HatchType ENERGY_OUTPUT = register(MI.id("energy_output"), MIText.EnergyOutputHatch);
+    public static final HatchType NUCLEAR_ITEM = register(MI.id("nuclear_item"), MI.id("nuclear_item_hatch"));
+    public static final HatchType NUCLEAR_FLUID = register(MI.id("nuclear_fluid"), MI.id("nuclear_fluid_hatch"));
+    public static final HatchType LARGE_TANK = register(MI.id("large_tank"), MI.id("large_tank_hatch"));
 
-    public static HatchType create(ResourceLocation id, MutableComponent description) {
+    public static HatchType register(ResourceLocation id, MutableComponent description) {
         if (registeredHatches.containsKey(id)) {
             throw new IllegalArgumentException("Duplicate hatch type definition: " + id);
         }
@@ -53,11 +53,11 @@ public class HatchTypes {
         return type;
     }
 
-    public static HatchType create(ResourceLocation id, MIText description) {
-        return create(id, description.text());
+    public static HatchType register(ResourceLocation id, MIText description) {
+        return register(id, description.text());
     }
 
-    public static HatchType create(ResourceLocation id, ResourceLocation blockId) {
+    public static HatchType register(ResourceLocation id, ResourceLocation blockId) {
         if (registeredHatches.containsKey(id)) {
             throw new IllegalArgumentException("Duplicate hatch type definition: " + id);
         }


### PR DESCRIPTION
This changes `HatchType` from being an enum to being a class structured similarly to `MachineCasing` so addons can add custom hatch types.