### PR TITLE
Allow namespaces on AbstractCraftingMultiblockBlockEntity

### DIFF
--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/AbstractCraftingMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/AbstractCraftingMultiblockBlockEntity.java
@@ -35,12 +35,13 @@ import aztech.modern_industrialization.machines.multiblocks.MultiblockMachineBlo
 import aztech.modern_industrialization.machines.multiblocks.ShapeMatcher;
 import aztech.modern_industrialization.machines.multiblocks.ShapeTemplate;
 import aztech.modern_industrialization.util.Tickable;
+import net.minecraft.resources.ResourceLocation;
 
 public abstract class AbstractCraftingMultiblockBlockEntity extends MultiblockMachineBlockEntity implements Tickable,
         MultiblockInventoryComponentHolder, CrafterComponentHolder {
-    public AbstractCraftingMultiblockBlockEntity(BEP bep, String name, OrientationComponent.Params orientationParams,
+    private AbstractCraftingMultiblockBlockEntity(BEP bep, MachineGuiParameters.Builder guiParams, OrientationComponent.Params orientationParams,
             ShapeTemplate[] shapeTemplates) {
-        super(bep, new MachineGuiParameters.Builder(name, false).backgroundHeight(200).build(), orientationParams);
+        super(bep, guiParams.backgroundHeight(200).build(), orientationParams);
 
         this.activeShape = new ActiveShapeComponent(shapeTemplates);
         this.inventory = new MultiblockInventoryComponent();
@@ -48,6 +49,16 @@ public abstract class AbstractCraftingMultiblockBlockEntity extends MultiblockMa
         this.isActive = new IsActiveComponent();
         registerGuiComponent(new ReiSlotLocking.Server(crafter::lockRecipe, () -> operatingState != OperatingState.NOT_MATCHED));
         registerComponents(activeShape, crafter, isActive);
+    }
+
+    public AbstractCraftingMultiblockBlockEntity(BEP bep, String name, OrientationComponent.Params orientationParams,
+            ShapeTemplate[] shapeTemplates) {
+        this(bep, new MachineGuiParameters.Builder(name, false), orientationParams, shapeTemplates);
+    }
+
+    public AbstractCraftingMultiblockBlockEntity(BEP bep, ResourceLocation blockId, OrientationComponent.Params orientationParams,
+            ShapeTemplate[] shapeTemplates) {
+        this(bep, new MachineGuiParameters.Builder(blockId, false), orientationParams, shapeTemplates);
     }
 
     /**

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/AbstractCraftingMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/AbstractCraftingMultiblockBlockEntity.java
@@ -39,7 +39,7 @@ import net.minecraft.resources.ResourceLocation;
 
 public abstract class AbstractCraftingMultiblockBlockEntity extends MultiblockMachineBlockEntity implements Tickable,
         MultiblockInventoryComponentHolder, CrafterComponentHolder {
-    private AbstractCraftingMultiblockBlockEntity(BEP bep, MachineGuiParameters.Builder guiParams, OrientationComponent.Params orientationParams,
+    public AbstractCraftingMultiblockBlockEntity(BEP bep, MachineGuiParameters.Builder guiParams, OrientationComponent.Params orientationParams,
             ShapeTemplate[] shapeTemplates) {
         super(bep, guiParams.backgroundHeight(200).build(), orientationParams);
 

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/AbstractCraftingMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/AbstractCraftingMultiblockBlockEntity.java
@@ -23,6 +23,7 @@
  */
 package aztech.modern_industrialization.machines.blockentities.multiblocks;
 
+import aztech.modern_industrialization.MI;
 import aztech.modern_industrialization.api.machine.holder.CrafterComponentHolder;
 import aztech.modern_industrialization.api.machine.holder.MultiblockInventoryComponentHolder;
 import aztech.modern_industrialization.inventory.MIInventory;
@@ -39,9 +40,9 @@ import net.minecraft.resources.ResourceLocation;
 
 public abstract class AbstractCraftingMultiblockBlockEntity extends MultiblockMachineBlockEntity implements Tickable,
         MultiblockInventoryComponentHolder, CrafterComponentHolder {
-    public AbstractCraftingMultiblockBlockEntity(BEP bep, MachineGuiParameters.Builder guiParams, OrientationComponent.Params orientationParams,
+    public AbstractCraftingMultiblockBlockEntity(BEP bep, ResourceLocation blockId, OrientationComponent.Params orientationParams,
             ShapeTemplate[] shapeTemplates) {
-        super(bep, guiParams.backgroundHeight(200).build(), orientationParams);
+        super(bep, new MachineGuiParameters.Builder(blockId, false).backgroundHeight(200).build(), orientationParams);
 
         this.activeShape = new ActiveShapeComponent(shapeTemplates);
         this.inventory = new MultiblockInventoryComponent();
@@ -53,12 +54,7 @@ public abstract class AbstractCraftingMultiblockBlockEntity extends MultiblockMa
 
     public AbstractCraftingMultiblockBlockEntity(BEP bep, String name, OrientationComponent.Params orientationParams,
             ShapeTemplate[] shapeTemplates) {
-        this(bep, new MachineGuiParameters.Builder(name, false), orientationParams, shapeTemplates);
-    }
-
-    public AbstractCraftingMultiblockBlockEntity(BEP bep, ResourceLocation blockId, OrientationComponent.Params orientationParams,
-            ShapeTemplate[] shapeTemplates) {
-        this(bep, new MachineGuiParameters.Builder(blockId, false), orientationParams, shapeTemplates);
+        this(bep, MI.id(name), orientationParams, shapeTemplates);
     }
 
     /**

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/AbstractElectricCraftingMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/AbstractElectricCraftingMultiblockBlockEntity.java
@@ -23,10 +23,10 @@
  */
 package aztech.modern_industrialization.machines.blockentities.multiblocks;
 
+import aztech.modern_industrialization.MI;
 import aztech.modern_industrialization.api.machine.holder.EnergyListComponentHolder;
 import aztech.modern_industrialization.machines.BEP;
 import aztech.modern_industrialization.machines.components.*;
-import aztech.modern_industrialization.machines.gui.MachineGuiParameters;
 import aztech.modern_industrialization.machines.guicomponents.CraftingMultiblockGui;
 import aztech.modern_industrialization.machines.multiblocks.HatchBlockEntity;
 import aztech.modern_industrialization.machines.multiblocks.ShapeMatcher;
@@ -46,10 +46,10 @@ import org.jetbrains.annotations.Nullable;
 public abstract class AbstractElectricCraftingMultiblockBlockEntity extends AbstractCraftingMultiblockBlockEntity
         implements EnergyListComponentHolder, CrafterComponent.Behavior {
 
-    public AbstractElectricCraftingMultiblockBlockEntity(BEP bep, MachineGuiParameters.Builder guiParams,
+    public AbstractElectricCraftingMultiblockBlockEntity(BEP bep, ResourceLocation blockId,
             OrientationComponent.Params orientationParams,
             ShapeTemplate[] shapeTemplates) {
-        super(bep, guiParams, orientationParams, shapeTemplates);
+        super(bep, blockId, orientationParams, shapeTemplates);
 
         this.redstoneControl = new RedstoneControlComponent();
         registerGuiComponent(new CraftingMultiblockGui.Server(() -> shapeValid.shapeValid, crafter::getProgress, crafter, () -> 0));
@@ -58,12 +58,7 @@ public abstract class AbstractElectricCraftingMultiblockBlockEntity extends Abst
 
     public AbstractElectricCraftingMultiblockBlockEntity(BEP bep, String name, OrientationComponent.Params orientationParams,
             ShapeTemplate[] shapeTemplates) {
-        this(bep, new MachineGuiParameters.Builder(name, false), orientationParams, shapeTemplates);
-    }
-
-    public AbstractElectricCraftingMultiblockBlockEntity(BEP bep, ResourceLocation blockId, OrientationComponent.Params orientationParams,
-            ShapeTemplate[] shapeTemplates) {
-        this(bep, new MachineGuiParameters.Builder(blockId, false), orientationParams, shapeTemplates);
+        this(bep, MI.id(name), orientationParams, shapeTemplates);
     }
 
     protected final RedstoneControlComponent redstoneControl;

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/AbstractElectricCraftingMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/AbstractElectricCraftingMultiblockBlockEntity.java
@@ -26,6 +26,7 @@ package aztech.modern_industrialization.machines.blockentities.multiblocks;
 import aztech.modern_industrialization.api.machine.holder.EnergyListComponentHolder;
 import aztech.modern_industrialization.machines.BEP;
 import aztech.modern_industrialization.machines.components.*;
+import aztech.modern_industrialization.machines.gui.MachineGuiParameters;
 import aztech.modern_industrialization.machines.guicomponents.CraftingMultiblockGui;
 import aztech.modern_industrialization.machines.multiblocks.HatchBlockEntity;
 import aztech.modern_industrialization.machines.multiblocks.ShapeMatcher;
@@ -35,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.ItemInteractionResult;
@@ -44,13 +46,24 @@ import org.jetbrains.annotations.Nullable;
 public abstract class AbstractElectricCraftingMultiblockBlockEntity extends AbstractCraftingMultiblockBlockEntity
         implements EnergyListComponentHolder, CrafterComponent.Behavior {
 
-    public AbstractElectricCraftingMultiblockBlockEntity(BEP bep, String name, OrientationComponent.Params orientationParams,
+    public AbstractElectricCraftingMultiblockBlockEntity(BEP bep, MachineGuiParameters.Builder guiParams,
+            OrientationComponent.Params orientationParams,
             ShapeTemplate[] shapeTemplates) {
-        super(bep, name, orientationParams, shapeTemplates);
+        super(bep, guiParams, orientationParams, shapeTemplates);
 
         this.redstoneControl = new RedstoneControlComponent();
         registerGuiComponent(new CraftingMultiblockGui.Server(() -> shapeValid.shapeValid, crafter::getProgress, crafter, () -> 0));
         registerComponents(redstoneControl);
+    }
+
+    public AbstractElectricCraftingMultiblockBlockEntity(BEP bep, String name, OrientationComponent.Params orientationParams,
+            ShapeTemplate[] shapeTemplates) {
+        this(bep, new MachineGuiParameters.Builder(name, false), orientationParams, shapeTemplates);
+    }
+
+    public AbstractElectricCraftingMultiblockBlockEntity(BEP bep, ResourceLocation blockId, OrientationComponent.Params orientationParams,
+            ShapeTemplate[] shapeTemplates) {
+        this(bep, new MachineGuiParameters.Builder(blockId, false), orientationParams, shapeTemplates);
     }
 
     protected final RedstoneControlComponent redstoneControl;

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/ElectricCraftingMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/ElectricCraftingMultiblockBlockEntity.java
@@ -23,10 +23,10 @@
  */
 package aztech.modern_industrialization.machines.blockentities.multiblocks;
 
+import aztech.modern_industrialization.MI;
 import aztech.modern_industrialization.api.machine.holder.EnergyListComponentHolder;
 import aztech.modern_industrialization.machines.BEP;
 import aztech.modern_industrialization.machines.components.*;
-import aztech.modern_industrialization.machines.gui.MachineGuiParameters;
 import aztech.modern_industrialization.machines.guicomponents.SlotPanel;
 import aztech.modern_industrialization.machines.init.MachineTier;
 import aztech.modern_industrialization.machines.multiblocks.ShapeTemplate;
@@ -34,9 +34,9 @@ import aztech.modern_industrialization.machines.recipe.MachineRecipeType;
 import net.minecraft.resources.ResourceLocation;
 
 public class ElectricCraftingMultiblockBlockEntity extends AbstractElectricCraftingMultiblockBlockEntity implements EnergyListComponentHolder {
-    public ElectricCraftingMultiblockBlockEntity(BEP bep, MachineGuiParameters.Builder guiParams, ShapeTemplate shapeTemplate,
+    public ElectricCraftingMultiblockBlockEntity(BEP bep, ResourceLocation blockId, ShapeTemplate shapeTemplate,
             MachineRecipeType recipeType) {
-        super(bep, guiParams, new OrientationComponent.Params(false, false, false), new ShapeTemplate[] { shapeTemplate });
+        super(bep, blockId, new OrientationComponent.Params(false, false, false), new ShapeTemplate[] { shapeTemplate });
         this.recipeType = recipeType;
         this.upgrades = new UpgradeComponent();
         this.overdrive = new OverdriveComponent();
@@ -48,11 +48,7 @@ public class ElectricCraftingMultiblockBlockEntity extends AbstractElectricCraft
     }
 
     public ElectricCraftingMultiblockBlockEntity(BEP bep, String name, ShapeTemplate shapeTemplate, MachineRecipeType recipeType) {
-        this(bep, new MachineGuiParameters.Builder(name, false), shapeTemplate, recipeType);
-    }
-
-    public ElectricCraftingMultiblockBlockEntity(BEP bep, ResourceLocation blockId, ShapeTemplate shapeTemplate, MachineRecipeType recipeType) {
-        this(bep, new MachineGuiParameters.Builder(blockId, false), shapeTemplate, recipeType);
+        this(bep, MI.id(name), shapeTemplate, recipeType);
     }
 
     private final MachineRecipeType recipeType;

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/ElectricCraftingMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/ElectricCraftingMultiblockBlockEntity.java
@@ -26,14 +26,17 @@ package aztech.modern_industrialization.machines.blockentities.multiblocks;
 import aztech.modern_industrialization.api.machine.holder.EnergyListComponentHolder;
 import aztech.modern_industrialization.machines.BEP;
 import aztech.modern_industrialization.machines.components.*;
+import aztech.modern_industrialization.machines.gui.MachineGuiParameters;
 import aztech.modern_industrialization.machines.guicomponents.SlotPanel;
 import aztech.modern_industrialization.machines.init.MachineTier;
 import aztech.modern_industrialization.machines.multiblocks.ShapeTemplate;
 import aztech.modern_industrialization.machines.recipe.MachineRecipeType;
+import net.minecraft.resources.ResourceLocation;
 
 public class ElectricCraftingMultiblockBlockEntity extends AbstractElectricCraftingMultiblockBlockEntity implements EnergyListComponentHolder {
-    public ElectricCraftingMultiblockBlockEntity(BEP bep, String name, ShapeTemplate shapeTemplate, MachineRecipeType recipeType) {
-        super(bep, name, new OrientationComponent.Params(false, false, false), new ShapeTemplate[] { shapeTemplate });
+    public ElectricCraftingMultiblockBlockEntity(BEP bep, MachineGuiParameters.Builder guiParams, ShapeTemplate shapeTemplate,
+            MachineRecipeType recipeType) {
+        super(bep, guiParams, new OrientationComponent.Params(false, false, false), new ShapeTemplate[] { shapeTemplate });
         this.recipeType = recipeType;
         this.upgrades = new UpgradeComponent();
         this.overdrive = new OverdriveComponent();
@@ -42,6 +45,14 @@ public class ElectricCraftingMultiblockBlockEntity extends AbstractElectricCraft
                 .withRedstoneControl(redstoneControl)
                 .withUpgrades(upgrades)
                 .withOverdrive(overdrive));
+    }
+
+    public ElectricCraftingMultiblockBlockEntity(BEP bep, String name, ShapeTemplate shapeTemplate, MachineRecipeType recipeType) {
+        this(bep, new MachineGuiParameters.Builder(name, false), shapeTemplate, recipeType);
+    }
+
+    public ElectricCraftingMultiblockBlockEntity(BEP bep, ResourceLocation blockId, ShapeTemplate shapeTemplate, MachineRecipeType recipeType) {
+        this(bep, new MachineGuiParameters.Builder(blockId, false), shapeTemplate, recipeType);
     }
 
     private final MachineRecipeType recipeType;

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/SteamCraftingMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/SteamCraftingMultiblockBlockEntity.java
@@ -23,11 +23,11 @@
  */
 package aztech.modern_industrialization.machines.blockentities.multiblocks;
 
+import aztech.modern_industrialization.MI;
 import aztech.modern_industrialization.machines.BEP;
 import aztech.modern_industrialization.machines.components.CrafterComponent;
 import aztech.modern_industrialization.machines.components.OrientationComponent;
 import aztech.modern_industrialization.machines.components.OverclockComponent;
-import aztech.modern_industrialization.machines.gui.MachineGuiParameters;
 import aztech.modern_industrialization.machines.guicomponents.CraftingMultiblockGui;
 import aztech.modern_industrialization.machines.helper.SteamHelper;
 import aztech.modern_industrialization.machines.multiblocks.HatchBlockEntity;
@@ -50,10 +50,10 @@ public class SteamCraftingMultiblockBlockEntity extends AbstractCraftingMultiblo
 
     private final OverclockComponent overclockComponent;
 
-    public SteamCraftingMultiblockBlockEntity(BEP bep, MachineGuiParameters.Builder guiParams, ShapeTemplate shapeTemplate,
+    public SteamCraftingMultiblockBlockEntity(BEP bep, ResourceLocation blockId, ShapeTemplate shapeTemplate,
             MachineRecipeType recipeType,
             List<OverclockComponent.Catalyst> overclockCatalysts) {
-        super(bep, guiParams, new OrientationComponent.Params(false, false, false), new ShapeTemplate[] { shapeTemplate });
+        super(bep, blockId, new OrientationComponent.Params(false, false, false), new ShapeTemplate[] { shapeTemplate });
 
         this.overclockComponent = new OverclockComponent(overclockCatalysts);
         this.recipeType = recipeType;
@@ -64,12 +64,7 @@ public class SteamCraftingMultiblockBlockEntity extends AbstractCraftingMultiblo
 
     public SteamCraftingMultiblockBlockEntity(BEP bep, String name, ShapeTemplate shapeTemplate, MachineRecipeType recipeType,
             List<OverclockComponent.Catalyst> overclockCatalysts) {
-        this(bep, new MachineGuiParameters.Builder(name, false), shapeTemplate, recipeType, overclockCatalysts);
-    }
-
-    public SteamCraftingMultiblockBlockEntity(BEP bep, ResourceLocation blockId, ShapeTemplate shapeTemplate, MachineRecipeType recipeType,
-            List<OverclockComponent.Catalyst> overclockCatalysts) {
-        this(bep, new MachineGuiParameters.Builder(blockId, false), shapeTemplate, recipeType, overclockCatalysts);
+        this(bep, MI.id(name), shapeTemplate, recipeType, overclockCatalysts);
     }
 
     @Override

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/SteamCraftingMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/SteamCraftingMultiblockBlockEntity.java
@@ -27,6 +27,7 @@ import aztech.modern_industrialization.machines.BEP;
 import aztech.modern_industrialization.machines.components.CrafterComponent;
 import aztech.modern_industrialization.machines.components.OrientationComponent;
 import aztech.modern_industrialization.machines.components.OverclockComponent;
+import aztech.modern_industrialization.machines.gui.MachineGuiParameters;
 import aztech.modern_industrialization.machines.guicomponents.CraftingMultiblockGui;
 import aztech.modern_industrialization.machines.helper.SteamHelper;
 import aztech.modern_industrialization.machines.multiblocks.HatchBlockEntity;
@@ -38,6 +39,7 @@ import java.util.List;
 import java.util.UUID;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.ItemInteractionResult;
@@ -48,15 +50,26 @@ public class SteamCraftingMultiblockBlockEntity extends AbstractCraftingMultiblo
 
     private final OverclockComponent overclockComponent;
 
-    public SteamCraftingMultiblockBlockEntity(BEP bep, String name, ShapeTemplate shapeTemplate, MachineRecipeType recipeType,
+    public SteamCraftingMultiblockBlockEntity(BEP bep, MachineGuiParameters.Builder guiParams, ShapeTemplate shapeTemplate,
+            MachineRecipeType recipeType,
             List<OverclockComponent.Catalyst> overclockCatalysts) {
-        super(bep, name, new OrientationComponent.Params(false, false, false), new ShapeTemplate[] { shapeTemplate });
+        super(bep, guiParams, new OrientationComponent.Params(false, false, false), new ShapeTemplate[] { shapeTemplate });
 
         this.overclockComponent = new OverclockComponent(overclockCatalysts);
         this.recipeType = recipeType;
         registerGuiComponent(
                 new CraftingMultiblockGui.Server(() -> shapeValid.shapeValid, crafter::getProgress, crafter, overclockComponent::getTicks));
         this.registerComponents(overclockComponent);
+    }
+
+    public SteamCraftingMultiblockBlockEntity(BEP bep, String name, ShapeTemplate shapeTemplate, MachineRecipeType recipeType,
+            List<OverclockComponent.Catalyst> overclockCatalysts) {
+        this(bep, new MachineGuiParameters.Builder(name, false), shapeTemplate, recipeType, overclockCatalysts);
+    }
+
+    public SteamCraftingMultiblockBlockEntity(BEP bep, ResourceLocation blockId, ShapeTemplate shapeTemplate, MachineRecipeType recipeType,
+            List<OverclockComponent.Catalyst> overclockCatalysts) {
+        this(bep, new MachineGuiParameters.Builder(blockId, false), shapeTemplate, recipeType, overclockCatalysts);
     }
 
     @Override


### PR DESCRIPTION
`AbstractCraftingMultiblockBlockEntity` slipped through the cracks back in #838 