### PR TITLE
Lock multiple slots when transferring recipes from EMI if necessary

### DIFF
--- a/src/main/java/aztech/modern_industrialization/inventory/ConfigurableFluidStack.java
+++ b/src/main/java/aztech/modern_industrialization/inventory/ConfigurableFluidStack.java
@@ -163,6 +163,7 @@ public class ConfigurableFluidStack extends AbstractConfigurableStack<Fluid, Flu
         return FluidVariant.fromNbt(compound, registries);
     }
 
+    @Override
     public long getCapacity() {
         return capacity;
     }
@@ -170,6 +171,11 @@ public class ConfigurableFluidStack extends AbstractConfigurableStack<Fluid, Flu
     @Override
     protected long getRemainingCapacityFor(FluidVariant key) {
         return getRemainingSpace();
+    }
+
+    @Override
+    public long getTotalCapacityFor(Fluid instance) {
+        return capacity;
     }
 
     public void setAmount(long amount) {

--- a/src/main/java/aztech/modern_industrialization/inventory/ConfigurableItemStack.java
+++ b/src/main/java/aztech/modern_industrialization/inventory/ConfigurableItemStack.java
@@ -153,6 +153,11 @@ public class ConfigurableItemStack extends AbstractConfigurableStack<Item, ItemV
         return Math.min(key.getMaxStackSize(), adjustedCapacity) - amount;
     }
 
+    @Override
+    public long getTotalCapacityFor(Item instance) {
+        return Math.min(ItemVariant.of(instance).getMaxStackSize(), adjustedCapacity);
+    }
+
     /**
      * Create a copy of a list of configurable fluid stacks.
      */


### PR DESCRIPTION
In particular this applies to recipes that require multiple non-stackable items (e.g. heat exchangers).