### PR TITLE
Fix #1157: Wrong block multiblock highlight not always working

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,38 +63,11 @@ repositories {
         }
     }
     maven {
-        name 'Jitpack for MI'
+        name 'Jitpack'
         url 'https://jitpack.io'
         content {
-            includeGroup "com.github.KubeJS-Mods"
-            includeGroup "com.github.GabrielOlvH"
-            /* For Magna */
-            includeGroup "com.github.Draylar.omega-config"
-            /* For KubeJS */
-            includeGroup "com.github.llamalad7.mixinextras"
             // For KubeJS
             includeGroup "com.github.rtyley"
-        }
-    }
-    // to build indrev
-    maven {
-        name = "CottonMC"
-        url = "https://server.bbkr.space/artifactory/libs-release"
-        content {
-            includeGroup "io.github.cottonmc"
-        }
-    }
-    maven {
-        name = "dblsaiko"
-        url = "https://maven.dblsaiko.net/"
-    }
-    maven {
-        name = "Technici4n"
-        url = "https://raw.githubusercontent.com/Technici4n/Technici4n-maven/master/"
-        content {
-            includeGroup "net.fabricmc.fabric-api"
-            includeGroup "dev.technici4n"
-            includeGroup "dev.latvian.mods"
         }
     }
     maven {
@@ -103,23 +76,11 @@ repositories {
             includeGroup "dev.ftb.mods"
         }
     }
-    maven {
-        url "https://maven.parchmentmc.net/"
-        content {
-            includeGroup "org.parchmentmc.data"
-        }
-    }
-    // For the "No Indium?" mod
-    maven {
-        url = 'https://maven.cafeteria.dev/releases/'
-        content {
-            includeGroup "me.luligabi"
-        }
-    }
     // For KubeJS & FTBTeams/FTBQuests
     maven {
         url "https://maven.latvian.dev/releases"
         content {
+            includeGroup "dev.latvian.apps"
             includeGroup "dev.latvian.mods"
             includeGroup "dev.ftb.mods"
         }

--- a/src/client/java/aztech/modern_industrialization/client/QuadCube.java
+++ b/src/client/java/aztech/modern_industrialization/client/QuadCube.java
@@ -1,0 +1,66 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Azercoco & Technici4n
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package aztech.modern_industrialization.client;
+
+import aztech.modern_industrialization.thirdparty.fabricrendering.MutableQuadView;
+import aztech.modern_industrialization.thirdparty.fabricrendering.QuadBuffer;
+import aztech.modern_industrialization.thirdparty.fabricrendering.QuadEmitter;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.inventory.InventoryMenu;
+import org.jetbrains.annotations.Nullable;
+
+public class QuadCube {
+    private final ResourceLocation spriteLocation;
+    @Nullable
+    private BakedQuad[] quads;
+
+    public QuadCube(ResourceLocation spriteLocation) {
+        this.spriteLocation = spriteLocation;
+    }
+
+    public BakedQuad[] getQuads() {
+        var sprite = Minecraft.getInstance().getTextureAtlas(InventoryMenu.BLOCK_ATLAS).apply(spriteLocation);
+        // Rebuild quads if the sprite changed
+        if (quads == null || quads[0].getSprite() != sprite) {
+            quads = buildQuads(sprite);
+        }
+        return quads;
+    }
+
+    private static BakedQuad[] buildQuads(TextureAtlasSprite sprite) {
+        var quads = new BakedQuad[6];
+        for (Direction direction : Direction.values()) {
+            QuadEmitter emitter = new QuadBuffer();
+            emitter.square(direction, 0, 0, 1, 1, 0);
+            emitter.spriteBake(sprite, MutableQuadView.BAKE_LOCK_UV);
+            quads[direction.get3DDataValue()] = emitter.toBakedQuad(sprite);
+        }
+        return quads;
+    }
+}

--- a/src/client/java/aztech/modern_industrialization/machines/multiblocks/MultiblockErrorHighlight.java
+++ b/src/client/java/aztech/modern_industrialization/machines/multiblocks/MultiblockErrorHighlight.java
@@ -30,6 +30,7 @@ import com.mojang.blaze3d.vertex.ByteBufferBuilder;
 import java.util.HashMap;
 import java.util.Map;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.BlockPos;
@@ -72,9 +73,9 @@ public class MultiblockErrorHighlight {
 
                 BlockState state = entry.getValue();
                 if (state == null) {
-                    RenderHelper.drawCube(poseStack, immediate, 1, 50f / 256, 50f / 256, 15728880, OverlayTexture.NO_OVERLAY);
+                    RenderHelper.drawCube(poseStack, immediate, 1, 50f / 256, 50f / 256, LightTexture.FULL_BRIGHT, OverlayTexture.NO_OVERLAY);
                 } else {
-                    Minecraft.getInstance().getBlockRenderer().renderSingleBlock(state, poseStack, immediate, 15728880,
+                    Minecraft.getInstance().getBlockRenderer().renderSingleBlock(state, poseStack, immediate, LightTexture.FULL_BRIGHT,
                             OverlayTexture.NO_OVERLAY);
                 }
 


### PR DESCRIPTION
The bug was that I forgot to set the uv of the quads. They are now set to the `neoforge:white` texture.