### PR TITLE
Fix #1208: Migrate to StreamCodecs for GUI components

### DIFF
--- a/src/client/java/aztech/modern_industrialization/compat/viewer/impl/MachineScreenPredicateTest.java
+++ b/src/client/java/aztech/modern_industrialization/compat/viewer/impl/MachineScreenPredicateTest.java
@@ -34,8 +34,8 @@ public class MachineScreenPredicateTest {
         return switch (predicate) {
             case ANY -> true;
             case MULTIBLOCK -> {
-                for (GuiComponentClient client : screen.getMenu().components) {
-                    if (client instanceof CraftingMultiblockGuiClient cmGui && cmGui.isShapeValid) {
+                for (GuiComponentClient<?, ?> client : screen.getMenu().components) {
+                    if (client instanceof CraftingMultiblockGuiClient cmGui && cmGui.isShapeValid()) {
                         yield true;
                     }
                 }

--- a/src/client/java/aztech/modern_industrialization/items/SteamDrillTooltipComponent.java
+++ b/src/client/java/aztech/modern_industrialization/items/SteamDrillTooltipComponent.java
@@ -56,7 +56,7 @@ public class SteamDrillTooltipComponent implements ClientTooltipComponent {
         // Stack itself
         RenderHelper.renderAndDecorateItem(guiGraphics, font, data.variant().toStack((int) data.amount()), x + 1, y + 1);
         // Burning flame next to the stack
-        var progressParams = new ProgressBar.Parameters(0, 0, "furnace", 14, 14, true);
+        var progressParams = new ProgressBar.Params(0, 0, "furnace", 14, 14, true);
         ProgressBarClient.renderProgress(guiGraphics, x + 20, y, progressParams, (float) data.burnTicks() / data.maxBurnTicks());
     }
 }

--- a/src/client/java/aztech/modern_industrialization/machines/gui/GuiComponentClient.java
+++ b/src/client/java/aztech/modern_industrialization/machines/gui/GuiComponentClient.java
@@ -24,28 +24,21 @@
 
 package aztech.modern_industrialization.machines.gui;
 
-import net.minecraft.network.RegistryFriendlyByteBuf;
-
 /**
  * Client part of a synced component.
  */
-public interface GuiComponentClient extends GuiComponent.Common {
-    /**
-     * Read the current data, written by {@link GuiComponent.Server#writeCurrentData}.
-     */
-    void readCurrentData(RegistryFriendlyByteBuf buf);
+// TODO: check every usage for rawtypes
+public abstract class GuiComponentClient<P, D> implements GuiComponent {
+    protected final P params;
+    protected D data;
+
+    protected GuiComponentClient(P params, D data) {
+        this.params = params;
+        this.data = data;
+    }
 
     /**
      * @return A new renderer linked to this client-side component.
      */
-    ClientComponentRenderer createRenderer(MachineScreen machineScreen);
-
-    @FunctionalInterface
-    interface Factory {
-        /**
-         * Create a new client synced component from the initial data, written by
-         * {@link GuiComponent.Server#writeInitialData}.
-         */
-        GuiComponentClient createFromInitialData(RegistryFriendlyByteBuf buf);
-    }
+    public abstract ClientComponentRenderer createRenderer(MachineScreen machineScreen);
 }

--- a/src/client/java/aztech/modern_industrialization/machines/gui/GuiComponentClient.java
+++ b/src/client/java/aztech/modern_industrialization/machines/gui/GuiComponentClient.java
@@ -27,7 +27,6 @@ package aztech.modern_industrialization.machines.gui;
 /**
  * Client part of a synced component.
  */
-// TODO: check every usage for rawtypes
 public abstract class GuiComponentClient<P, D> implements GuiComponent {
     protected final P params;
     protected D data;

--- a/src/client/java/aztech/modern_industrialization/machines/gui/MachineScreen.java
+++ b/src/client/java/aztech/modern_industrialization/machines/gui/MachineScreen.java
@@ -65,7 +65,7 @@ public class MachineScreen extends MIHandledScreen<MachineMenuClient> implements
     public MachineScreen(MachineMenuClient handler, Inventory inventory, Component title) {
         super(handler, inventory, title);
 
-        for (GuiComponentClient component : handler.components) {
+        for (GuiComponentClient<?, ?> component : handler.components) {
             renderers.add(component.createRenderer(this));
         }
 

--- a/src/client/java/aztech/modern_industrialization/machines/guicomponents/CraftingMultiblockGuiClient.java
+++ b/src/client/java/aztech/modern_industrialization/machines/guicomponents/CraftingMultiblockGuiClient.java
@@ -33,37 +33,16 @@ import aztech.modern_industrialization.util.TextHelper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Unit;
 
-public class CraftingMultiblockGuiClient implements GuiComponentClient {
-    public boolean isShapeValid;
-    boolean hasActiveRecipe;
-    float progress;
-    int efficiencyTicks;
-    int maxEfficiencyTicks;
-    long currentRecipeEu;
-    long baseRecipeEu;
-    int remainingOverclockTicks;
-
-    public CraftingMultiblockGuiClient(RegistryFriendlyByteBuf buf) {
-        readCurrentData(buf);
+public class CraftingMultiblockGuiClient extends GuiComponentClient<Unit, CraftingMultiblockGui.Data> {
+    public CraftingMultiblockGuiClient(Unit params, CraftingMultiblockGui.Data data) {
+        super(params, data);
     }
 
-    @Override
-    public void readCurrentData(RegistryFriendlyByteBuf buf) {
-        isShapeValid = buf.readBoolean();
-        if (isShapeValid) {
-            hasActiveRecipe = buf.readBoolean();
-            if (hasActiveRecipe) {
-                progress = buf.readFloat();
-                efficiencyTicks = buf.readInt();
-                maxEfficiencyTicks = buf.readInt();
-                currentRecipeEu = buf.readLong();
-                baseRecipeEu = buf.readLong();
-            }
-        }
-        remainingOverclockTicks = buf.readVarInt();
+    public boolean isShapeValid() {
+        return data.isShapeValid();
     }
 
     @Override
@@ -83,37 +62,41 @@ public class CraftingMultiblockGuiClient implements GuiComponentClient {
 
             int deltaY = 23;
 
-            guiGraphics.drawString(font, isShapeValid ? MIText.MultiblockShapeValid.text() : MIText.MultiblockShapeInvalid.text(), x + 10, y + deltaY,
-                    isShapeValid ? 0xFFFFFF : 0xFF0000, false);
+            guiGraphics.drawString(font,
+                    data.isShapeValid() ? MIText.MultiblockShapeValid.text() : MIText.MultiblockShapeInvalid.text(),
+                    x + 10, y + deltaY,
+                    data.isShapeValid() ? 0xFFFFFF : 0xFF0000, false);
             deltaY += 11;
 
-            if (isShapeValid) {
+            if (data.isShapeValid()) {
                 guiGraphics.drawString(font, MIText.MultiblockStatusActive.text(), x + 10, y + deltaY, 0xFFFFFF, false);
                 deltaY += 11;
 
-                if (hasActiveRecipe) {
-                    guiGraphics.drawString(font, MIText.Progress.text(String.format("%.1f", progress * 100) + " %"), x + 10, y + deltaY, 0xFFFFFF,
+                if (data.activeRecipe().isPresent()) {
+                    var recipe = data.activeRecipe().get();
+
+                    guiGraphics.drawString(font, MIText.Progress.text(String.format("%.1f", recipe.progress() * 100) + " %"), x + 10, y + deltaY, 0xFFFFFF,
                             false);
                     deltaY += 11;
 
-                    if (efficiencyTicks != 0 || maxEfficiencyTicks != 0) {
-                        guiGraphics.drawString(font, MIText.EfficiencyTicks.text(efficiencyTicks, maxEfficiencyTicks), x + 10, y + deltaY, 0xFFFFFF,
+                    if (recipe.efficiencyTicks() != 0 || recipe.maxEfficiencyTicks() != 0) {
+                        guiGraphics.drawString(font, MIText.EfficiencyTicks.text(recipe.efficiencyTicks(), recipe.maxEfficiencyTicks()), x + 10, y + deltaY, 0xFFFFFF,
                                 false);
                         deltaY += 11;
                     }
 
-                    guiGraphics.drawString(font, MIText.BaseEuRecipe.text(TextHelper.getEuTextTick(baseRecipeEu)), x + 10, y + deltaY, 0xFFFFFF,
+                    guiGraphics.drawString(font, MIText.BaseEuRecipe.text(TextHelper.getEuTextTick(recipe.baseRecipeEu())), x + 10, y + deltaY, 0xFFFFFF,
                             false);
                     deltaY += 11;
 
-                    guiGraphics.drawString(font, MIText.CurrentEuRecipe.text(TextHelper.getEuTextTick(currentRecipeEu)), x + 10, y + deltaY, 0xFFFFFF,
+                    guiGraphics.drawString(font, MIText.CurrentEuRecipe.text(TextHelper.getEuTextTick(recipe.currentRecipeEu())), x + 10, y + deltaY, 0xFFFFFF,
                             false);
                     deltaY += 11;
                 }
             }
 
-            if (remainingOverclockTicks > 0) {
-                guiGraphics.drawString(font, GunpowderOverclockGuiClient.Renderer.formatOverclock(remainingOverclockTicks), x + 10, y + deltaY,
+            if (data.remainingOverclockTicks() > 0) {
+                guiGraphics.drawString(font, GunpowderOverclockGuiClient.Renderer.formatOverclock(data.remainingOverclockTicks()), x + 10, y + deltaY,
                         0xFFFFFF, false);
             }
         }

--- a/src/client/java/aztech/modern_industrialization/machines/guicomponents/EnergyBarClient.java
+++ b/src/client/java/aztech/modern_industrialization/machines/guicomponents/EnergyBarClient.java
@@ -35,22 +35,11 @@ import java.util.Optional;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 
-public class EnergyBarClient implements GuiComponentClient {
-    final EnergyBar.Parameters params;
-    long eu, maxEu;
-
-    public EnergyBarClient(RegistryFriendlyByteBuf buf) {
-        this.params = new EnergyBar.Parameters(buf.readInt(), buf.readInt());
-        readCurrentData(buf);
-    }
-
-    @Override
-    public void readCurrentData(RegistryFriendlyByteBuf buf) {
-        eu = buf.readLong();
-        maxEu = buf.readLong();
+public class EnergyBarClient extends GuiComponentClient<EnergyBar.Params, EnergyBar.Data> {
+    public EnergyBarClient(EnergyBar.Params parameters, EnergyBar.Data data) {
+        super(parameters, data);
     }
 
     @Override
@@ -72,17 +61,17 @@ public class EnergyBarClient implements GuiComponentClient {
 
         @Override
         public void renderBackground(GuiGraphics guiGraphics, int x, int y) {
-            renderEnergy(guiGraphics, x + params.renderX, y + params.renderY, (float) eu / maxEu);
+            renderEnergy(guiGraphics, x + params.renderX(), y + params.renderY(), (float) data.eu() / data.maxEu());
         }
 
         @Override
         public void renderTooltip(MachineScreen screen, Font font, GuiGraphics guiGraphics, int x, int y, int cursorX, int cursorY) {
-            if (RenderHelper.isPointWithinRectangle(params.renderX, params.renderY, WIDTH, HEIGHT, cursorX - x, cursorY - y)) {
+            if (RenderHelper.isPointWithinRectangle(params.renderX(), params.renderY(), WIDTH, HEIGHT, cursorX - x, cursorY - y)) {
                 Component tooltip;
                 if (Screen.hasShiftDown()) {
-                    tooltip = MIText.EuMaxed.text(eu, maxEu, "");
+                    tooltip = MIText.EuMaxed.text(data.eu(), data.maxEu(), "");
                 } else {
-                    TextHelper.MaxedAmount maxedAmount = TextHelper.getMaxedAmount(eu, maxEu);
+                    TextHelper.MaxedAmount maxedAmount = TextHelper.getMaxedAmount(data.eu(), data.maxEu());
                     tooltip = MIText.EuMaxed.text(maxedAmount.digit(), maxedAmount.maxDigit(), maxedAmount.unit());
                 }
                 guiGraphics.renderTooltip(font, Collections.singletonList(tooltip), Optional.empty(), cursorX, cursorY);

--- a/src/client/java/aztech/modern_industrialization/machines/guicomponents/GunpowderOverclockGuiClient.java
+++ b/src/client/java/aztech/modern_industrialization/machines/guicomponents/GunpowderOverclockGuiClient.java
@@ -31,21 +31,11 @@ import aztech.modern_industrialization.machines.gui.MachineScreen;
 import aztech.modern_industrialization.util.RenderHelper;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 
-public class GunpowderOverclockGuiClient implements GuiComponentClient {
-    final GunpowderOverclockGui.Parameters params;
-    int remTick;
-
-    public GunpowderOverclockGuiClient(RegistryFriendlyByteBuf buf) {
-        this.params = new GunpowderOverclockGui.Parameters(buf.readInt(), buf.readInt());
-        readCurrentData(buf);
-    }
-
-    @Override
-    public void readCurrentData(RegistryFriendlyByteBuf buf) {
-        remTick = buf.readInt();
+public class GunpowderOverclockGuiClient extends GuiComponentClient<GunpowderOverclockGui.Params, Integer> {
+    public GunpowderOverclockGuiClient(GunpowderOverclockGui.Params params, Integer data) {
+        super(params, data);
     }
 
     @Override
@@ -56,18 +46,18 @@ public class GunpowderOverclockGuiClient implements GuiComponentClient {
     public class Renderer implements ClientComponentRenderer {
         @Override
         public void renderBackground(GuiGraphics guiGraphics, int x, int y) {
-            if (remTick > 0) {
-                int px = x + params.renderX;
-                int py = y + params.renderY;
+            if (data > 0) {
+                int px = x + params.renderX();
+                int py = y + params.renderY();
                 guiGraphics.blit(MachineScreen.SLOT_ATLAS, px, py, 0, 58, 20, 20);
             }
         }
 
         @Override
         public void renderTooltip(MachineScreen screen, Font font, GuiGraphics guiGraphics, int x, int y, int cursorX, int cursorY) {
-            if (remTick > 0) {
-                if (RenderHelper.isPointWithinRectangle(params.renderX, params.renderY, 20, 20, cursorX - x, cursorY - y)) {
-                    guiGraphics.renderTooltip(font, formatOverclock(remTick), cursorX, cursorY);
+            if (data > 0) {
+                if (RenderHelper.isPointWithinRectangle(params.renderX(), params.renderY(), 20, 20, cursorX - x, cursorY - y)) {
+                    guiGraphics.renderTooltip(font, formatOverclock(data), cursorX, cursorY);
                 }
             }
         }

--- a/src/client/java/aztech/modern_industrialization/machines/guicomponents/LargeTankFluidDisplayClient.java
+++ b/src/client/java/aztech/modern_industrialization/machines/guicomponents/LargeTankFluidDisplayClient.java
@@ -37,18 +37,11 @@ import java.util.Optional;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.util.Unit;
 
-public class LargeTankFluidDisplayClient implements GuiComponentClient {
-    LargeTankFluidDisplay.Data fluidData;
-
-    public LargeTankFluidDisplayClient(RegistryFriendlyByteBuf buf) {
-        readCurrentData(buf);
-    }
-
-    @Override
-    public void readCurrentData(RegistryFriendlyByteBuf buf) {
-        fluidData = new LargeTankFluidDisplay.Data(FluidVariant.fromPacket(buf), buf.readLong(), buf.readLong());
+public class LargeTankFluidDisplayClient extends GuiComponentClient<Unit, LargeTankFluidDisplay.Data> {
+    public LargeTankFluidDisplayClient(Unit params, LargeTankFluidDisplay.Data data) {
+        super(params, data);
     }
 
     @Override
@@ -58,8 +51,8 @@ public class LargeTankFluidDisplayClient implements GuiComponentClient {
 
             @Override
             public void renderBackground(GuiGraphics guiGraphics, int leftPos, int topPos) {
-                FluidVariant fluid = fluidData.fluid();
-                float fracFull = (float) fluidData.amount() / fluidData.capacity();
+                FluidVariant fluid = data.fluid();
+                float fracFull = (float) data.amount() / data.capacity();
 
                 guiGraphics.blit(MachineScreen.SLOT_ATLAS, leftPos + posX, topPos + posY, 92, 38, 46, 62);
 
@@ -82,9 +75,9 @@ public class LargeTankFluidDisplayClient implements GuiComponentClient {
                 var renderer = Objects.requireNonNull(shapeSelection).getRenderer();
                 if (renderer.isPanelOpen) {
                     var shapePanelBox = renderer.getBox(leftPos, topPos);
-                    int[] selectedShape = shapeSelection.currentData;
+                    var selectedShape = shapeSelection.getData();
                     long capacity = LargeTankMultiblockBlockEntity.getCapacityFromComponents(
-                            selectedShape[0], selectedShape[1], selectedShape[2]);
+                            selectedShape.get(0), selectedShape.get(1), selectedShape.get(2));
                     var capacityText = FluidHelper.getFluidAmountLarge(capacity);
 
                     guiGraphics.drawString(Minecraft.getInstance().font, capacityText, shapePanelBox.x() + 14, shapePanelBox.y() + 14, 0x404040,
@@ -96,7 +89,7 @@ public class LargeTankFluidDisplayClient implements GuiComponentClient {
             public void renderTooltip(MachineScreen screen, Font font, GuiGraphics guiGraphics, int x, int y, int cursorX, int cursorY) {
                 if (RenderHelper.isPointWithinRectangle(posX + 7, posY + 7, 32, 48, cursorX - x, cursorY - y)) {
                     guiGraphics.renderTooltip(font,
-                            FluidHelper.getTooltipForFluidStorage(fluidData.fluid(), fluidData.amount(), fluidData.capacity()),
+                            FluidHelper.getTooltipForFluidStorage(data.fluid(), data.amount(), data.capacity()),
                             Optional.empty(),
                             cursorX, cursorY);
                 }

--- a/src/client/java/aztech/modern_industrialization/machines/guicomponents/ProgressBarClient.java
+++ b/src/client/java/aztech/modern_industrialization/machines/guicomponents/ProgressBarClient.java
@@ -28,36 +28,26 @@ import aztech.modern_industrialization.machines.gui.ClientComponentRenderer;
 import aztech.modern_industrialization.machines.gui.GuiComponentClient;
 import aztech.modern_industrialization.machines.gui.MachineScreen;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.network.RegistryFriendlyByteBuf;
 
-public class ProgressBarClient implements GuiComponentClient {
-    public final ProgressBar.Parameters params;
-    public float progress;
-
-    public ProgressBarClient(RegistryFriendlyByteBuf buf) {
-        this.params = new ProgressBar.Parameters(buf.readInt(), buf.readInt(), buf.readUtf(), buf.readInt(), buf.readInt(), buf.readBoolean());
-        readCurrentData(buf);
+public class ProgressBarClient extends GuiComponentClient<ProgressBar.Params, Float> {
+    public ProgressBarClient(ProgressBar.Params params, Float data) {
+        super(params, data);
     }
 
-    public static void renderProgress(GuiGraphics guiGraphics, int x, int y, ProgressBar.Parameters params, float progress) {
+    public static void renderProgress(GuiGraphics guiGraphics, int x, int y, ProgressBar.Params params, float progress) {
         // background
-        guiGraphics.blit(params.getTextureId(), x + params.renderX, y + params.renderY, 0, 0, params.width, params.height, params.width, params.textureHeight());
+        guiGraphics.blit(params.getTextureId(), x + params.renderX(), y + params.renderY(), 0, 0, params.width(), params.height(), params.width(), params.textureHeight());
         // foreground
         if (progress > 0) {
-            if (!params.isVertical) {
-                int foregroundPixels = (int) (progress * params.width);
-                guiGraphics.blit(params.getTextureId(), x + params.renderX, y + params.renderY, 0, params.height, foregroundPixels, params.height, params.width, params.textureHeight());
+            if (!params.isVertical()) {
+                int foregroundPixels = (int) (progress * params.width());
+                guiGraphics.blit(params.getTextureId(), x + params.renderX(), y + params.renderY(), 0, params.height(), foregroundPixels, params.height(), params.width(), params.textureHeight());
             } else {
-                int foregroundPixels = (int) (progress * params.height);
-                guiGraphics.blit(params.getTextureId(), x + params.renderX, y + params.renderY + params.height - foregroundPixels, 0,
-                        params.textureHeight() - foregroundPixels, params.width, foregroundPixels, params.width, params.textureHeight());
+                int foregroundPixels = (int) (progress * params.height());
+                guiGraphics.blit(params.getTextureId(), x + params.renderX(), y + params.renderY() + params.height() - foregroundPixels, 0,
+                        params.textureHeight() - foregroundPixels, params.width(), foregroundPixels, params.width(), params.textureHeight());
             }
         }
-    }
-
-    @Override
-    public void readCurrentData(RegistryFriendlyByteBuf buf) {
-        this.progress = buf.readFloat();
     }
 
     @Override
@@ -68,7 +58,7 @@ public class ProgressBarClient implements GuiComponentClient {
     public class Renderer implements ClientComponentRenderer {
         @Override
         public void renderBackground(GuiGraphics guiGraphics, int x, int y) {
-            renderProgress(guiGraphics, x, y, params, progress);
+            renderProgress(guiGraphics, x, y, params, data);
         }
     }
 }

--- a/src/client/java/aztech/modern_industrialization/machines/guicomponents/RecipeEfficiencyBarClient.java
+++ b/src/client/java/aztech/modern_industrialization/machines/guicomponents/RecipeEfficiencyBarClient.java
@@ -36,34 +36,12 @@ import java.util.List;
 import java.util.Optional;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 
-public class RecipeEfficiencyBarClient implements GuiComponentClient {
-    final RecipeEfficiencyBar.Parameters params;
-    boolean hasActiveRecipe;
-    int efficiencyTicks;
-    int maxEfficiencyTicks;
-    long currentRecipeEu;
-    long baseRecipeEu;
-    long maxRecipeEu;
-
-    public RecipeEfficiencyBarClient(RegistryFriendlyByteBuf buf) {
-        this.params = new RecipeEfficiencyBar.Parameters(buf.readInt(), buf.readInt());
-        readCurrentData(buf);
-    }
-
-    @Override
-    public void readCurrentData(RegistryFriendlyByteBuf buf) {
-        hasActiveRecipe = buf.readBoolean();
-        if (hasActiveRecipe) {
-            efficiencyTicks = buf.readInt();
-            maxEfficiencyTicks = buf.readInt();
-            currentRecipeEu = buf.readLong();
-            baseRecipeEu = buf.readLong();
-        }
-        maxRecipeEu = buf.readLong();
+public class RecipeEfficiencyBarClient extends GuiComponentClient<RecipeEfficiencyBar.Params, RecipeEfficiencyBar.Data> {
+    public RecipeEfficiencyBarClient(RecipeEfficiencyBar.Params params, RecipeEfficiencyBar.Data data) {
+        super(params, data);
     }
 
     @Override
@@ -77,29 +55,29 @@ public class RecipeEfficiencyBarClient implements GuiComponentClient {
     public class Renderer implements ClientComponentRenderer {
         @Override
         public void renderBackground(GuiGraphics guiGraphics, int x, int y) {
-            guiGraphics.blit(TEXTURE, x + params.renderX - 1, y + params.renderY - 1, 0, 2, WIDTH + 2, HEIGHT + 2, 102, 6);
-            if (hasActiveRecipe) {
-                int barPixels = (int) ((float) efficiencyTicks / maxEfficiencyTicks * WIDTH);
-                guiGraphics.blit(TEXTURE, x + params.renderX, y + params.renderY, 0, 0, barPixels, HEIGHT, 102, 6);
+            guiGraphics.blit(TEXTURE, x + params.renderX() - 1, y + params.renderY() - 1, 0, 2, WIDTH + 2, HEIGHT + 2, 102, 6);
+            if (data.hasActiveRecipe()) {
+                int barPixels = (int) ((float) data.efficiencyTicks() / data.maxEfficiencyTicks() * WIDTH);
+                guiGraphics.blit(TEXTURE, x + params.renderX(), y + params.renderY(), 0, 0, barPixels, HEIGHT, 102, 6);
             }
         }
 
         @Override
         public void renderTooltip(MachineScreen screen, Font font, GuiGraphics guiGraphics, int x, int y, int cursorX, int cursorY) {
-            if (RenderHelper.isPointWithinRectangle(params.renderX, params.renderY, WIDTH, HEIGHT, cursorX - x, cursorY - y)) {
+            if (RenderHelper.isPointWithinRectangle(params.renderX(), params.renderY(), WIDTH, HEIGHT, cursorX - x, cursorY - y)) {
                 List<Component> tooltip = new ArrayList<>();
-                if (hasActiveRecipe) {
+                if (data.hasActiveRecipe()) {
                     DecimalFormat factorFormat = new DecimalFormat("#.#");
 
-                    tooltip.add(MIText.EfficiencyTicks.text(efficiencyTicks, maxEfficiencyTicks));
-                    tooltip.add(MIText.EfficiencyFactor.text(factorFormat.format((double) currentRecipeEu / baseRecipeEu)));
-                    tooltip.add(MIText.EfficiencyEu.text(currentRecipeEu));
+                    tooltip.add(MIText.EfficiencyTicks.text(data.efficiencyTicks(), data.maxEfficiencyTicks()));
+                    tooltip.add(MIText.EfficiencyFactor.text(factorFormat.format((double) data.currentRecipeEu() / data.baseRecipeEu())));
+                    tooltip.add(MIText.EfficiencyEu.text(data.currentRecipeEu()));
 
                 } else {
                     tooltip.add(MIText.EfficiencyDefaultMessage.text());
                 }
 
-                tooltip.add(MIText.EfficiencyMaxOverclock.text(maxRecipeEu));
+                tooltip.add(MIText.EfficiencyMaxOverclock.text(data.maxRecipeEu()));
 
                 guiGraphics.renderTooltip(font, tooltip, Optional.empty(), cursorX, cursorY);
             }

--- a/src/client/java/aztech/modern_industrialization/machines/guicomponents/ReiSlotLockingClient.java
+++ b/src/client/java/aztech/modern_industrialization/machines/guicomponents/ReiSlotLockingClient.java
@@ -27,22 +27,15 @@ package aztech.modern_industrialization.machines.guicomponents;
 import aztech.modern_industrialization.machines.gui.ClientComponentRenderer;
 import aztech.modern_industrialization.machines.gui.GuiComponentClient;
 import aztech.modern_industrialization.machines.gui.MachineScreen;
-import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.util.Unit;
 
-public class ReiSlotLockingClient implements GuiComponentClient {
-    private boolean allowLocking;
-
-    public ReiSlotLockingClient(RegistryFriendlyByteBuf initialData) {
-        readCurrentData(initialData);
+public class ReiSlotLockingClient extends GuiComponentClient<Unit, Boolean> {
+    public ReiSlotLockingClient(Unit params, Boolean data) {
+        super(params, data);
     }
 
     public boolean isLockingAllowed() {
-        return allowLocking;
-    }
-
-    @Override
-    public void readCurrentData(RegistryFriendlyByteBuf buf) {
-        allowLocking = buf.readBoolean();
+        return data;
     }
 
     @Override

--- a/src/client/java/aztech/modern_industrialization/machines/guicomponents/SlotPanelClient.java
+++ b/src/client/java/aztech/modern_industrialization/machines/guicomponents/SlotPanelClient.java
@@ -27,38 +27,28 @@ package aztech.modern_industrialization.machines.guicomponents;
 import aztech.modern_industrialization.MITooltips;
 import aztech.modern_industrialization.inventory.BackgroundRenderedSlot;
 import aztech.modern_industrialization.machines.gui.ClientComponentRenderer;
-import aztech.modern_industrialization.machines.gui.GuiComponent;
 import aztech.modern_industrialization.machines.gui.GuiComponentClient;
 import aztech.modern_industrialization.machines.gui.MachineScreen;
 import aztech.modern_industrialization.util.Rectangle;
-import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
+import net.minecraft.util.Unit;
 import net.minecraft.world.Container;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 
-public class SlotPanelClient implements GuiComponentClient {
-    private final List<SlotPanel.SlotType> slotTypes = new ArrayList<>();
-
-    public SlotPanelClient(RegistryFriendlyByteBuf buf) {
-        int slotCount = buf.readVarInt();
-        for (int i = 0; i < slotCount; ++i) {
-            slotTypes.add(buf.readEnum(SlotPanel.SlotType.class));
-        }
+public class SlotPanelClient extends GuiComponentClient<List<SlotPanel.SlotType>, Unit> {
+    public SlotPanelClient(List<SlotPanel.SlotType> params, Unit data) {
+        super(params, data);
     }
 
     @Override
-    public void readCurrentData(RegistryFriendlyByteBuf buf) {}
-
-    @Override
-    public void setupMenu(GuiComponent.MenuFacade menu) {
-        for (int i = 0; i < slotTypes.size(); ++i) {
-            var type = slotTypes.get(i);
+    public void setupMenu(MenuFacade menu) {
+        for (int i = 0; i < params.size(); ++i) {
+            var type = params.get(i);
 
             class ClientSlot extends SlotWithBackground implements SlotTooltip {
                 public ClientSlot(int i) {
@@ -99,7 +89,7 @@ public class SlotPanelClient implements GuiComponentClient {
     public ClientComponentRenderer createRenderer(MachineScreen machineScreen) {
         return new ClientComponentRenderer() {
             private Rectangle getBox(int leftPos, int topPos) {
-                return new Rectangle(leftPos + machineScreen.getGuiParams().backgroundWidth, topPos + 10, 31, 14 + 20 * slotTypes.size());
+                return new Rectangle(leftPos + machineScreen.getGuiParams().backgroundWidth, topPos + 10, 31, 14 + 20 * params.size());
             }
 
             @Override

--- a/src/client/java/aztech/modern_industrialization/machines/guicomponents/TemperatureBarClient.java
+++ b/src/client/java/aztech/modern_industrialization/machines/guicomponents/TemperatureBarClient.java
@@ -31,21 +31,11 @@ import aztech.modern_industrialization.machines.gui.GuiComponentClient;
 import aztech.modern_industrialization.machines.gui.MachineScreen;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 
-public class TemperatureBarClient implements GuiComponentClient {
-    public final TemperatureBar.Parameters params;
-    public int temperature;
-
-    public TemperatureBarClient(RegistryFriendlyByteBuf buf) {
-        this.params = new TemperatureBar.Parameters(buf.readInt(), buf.readInt(), buf.readInt());
-        readCurrentData(buf);
-    }
-
-    @Override
-    public void readCurrentData(RegistryFriendlyByteBuf buf) {
-        this.temperature = buf.readInt();
+public class TemperatureBarClient extends GuiComponentClient<TemperatureBar.Params, Integer> {
+    public TemperatureBarClient(TemperatureBar.Params params, Integer data) {
+        super(params, data);
     }
 
     @Override
@@ -60,19 +50,19 @@ public class TemperatureBarClient implements GuiComponentClient {
         @Override
         public void renderBackground(GuiGraphics guiGraphics, int x, int y) {
             // background
-            guiGraphics.blit(TEXTURE, x + params.renderX - 1, y + params.renderY - 1, 0, 2,
+            guiGraphics.blit(TEXTURE, x + params.renderX() - 1, y + params.renderY() - 1, 0, 2,
                     WIDTH + 2, HEIGHT + 2, 102, 6);
-            int barPixels = (int) ((float) temperature / params.temperatureMax * WIDTH);
-            guiGraphics.blit(TEXTURE, x + params.renderX, y + params.renderY, 0, 0, barPixels,
+            int barPixels = (int) ((float) data / params.temperatureMax() * WIDTH);
+            guiGraphics.blit(TEXTURE, x + params.renderX(), y + params.renderY(), 0, 0, barPixels,
                     HEIGHT, 102, 6);
-            guiGraphics.blit(MachineScreen.SLOT_ATLAS, x + params.renderX - 22, y + params.renderY + HEIGHT / 2 - 10, 144, 0, 20, 20);
+            guiGraphics.blit(MachineScreen.SLOT_ATLAS, x + params.renderX() - 22, y + params.renderY() + HEIGHT / 2 - 10, 144, 0, 20, 20);
         }
 
         @Override
         public void renderTooltip(MachineScreen screen, Font font, GuiGraphics guiGraphics, int x, int y, int cursorX, int cursorY) {
-            if (aztech.modern_industrialization.util.RenderHelper.isPointWithinRectangle(params.renderX, params.renderY, WIDTH, HEIGHT, cursorX - x,
+            if (aztech.modern_industrialization.util.RenderHelper.isPointWithinRectangle(params.renderX(), params.renderY(), WIDTH, HEIGHT, cursorX - x,
                     cursorY - y)) {
-                guiGraphics.renderTooltip(font, MIText.Temperature.text(temperature), cursorX, cursorY);
+                guiGraphics.renderTooltip(font, MIText.Temperature.text(data), cursorX, cursorY);
             }
         }
     }

--- a/src/main/java/aztech/modern_industrialization/compat/kubejs/machine/RegisterMachinesEventJS.java
+++ b/src/main/java/aztech/modern_industrialization/compat/kubejs/machine/RegisterMachinesEventJS.java
@@ -57,20 +57,20 @@ import net.minecraft.world.level.material.Fluid;
 
 @SuppressWarnings("unused")
 public class RegisterMachinesEventJS implements KubeEvent, ShapeTemplateHelper {
-    public ProgressBar.Parameters progressBar(int renderX, int renderY, String type) {
-        return new ProgressBar.Parameters(renderX, renderY, type);
+    public ProgressBar.Params progressBar(int renderX, int renderY, String type) {
+        return new ProgressBar.Params(renderX, renderY, type);
     }
 
-    public ProgressBar.Parameters progressBar(int renderX, int renderY, String type, int width, int height) {
-        return new ProgressBar.Parameters(renderX, renderY, type, width, height, false);
+    public ProgressBar.Params progressBar(int renderX, int renderY, String type, int width, int height) {
+        return new ProgressBar.Params(renderX, renderY, type, width, height, false);
     }
 
-    public RecipeEfficiencyBar.Parameters efficiencyBar(int renderX, int renderY) {
-        return new RecipeEfficiencyBar.Parameters(renderX, renderY);
+    public RecipeEfficiencyBar.Params efficiencyBar(int renderX, int renderY) {
+        return new RecipeEfficiencyBar.Params(renderX, renderY);
     }
 
-    public EnergyBar.Parameters energyBar(int renderX, int renderY) {
-        return new EnergyBar.Parameters(renderX, renderY);
+    public EnergyBar.Params energyBar(int renderX, int renderY) {
+        return new EnergyBar.Params(renderX, renderY);
     }
 
     public void craftingSingleBlock(
@@ -78,7 +78,7 @@ public class RegisterMachinesEventJS implements KubeEvent, ShapeTemplateHelper {
             String englishName, String internalName, MachineRecipeType recipeType, List<String> tiers,
             // gui
             int backgroundHeight, // can be -1 to use default
-            ProgressBar.Parameters progressBar, RecipeEfficiencyBar.Parameters efficiencyBar, EnergyBar.Parameters energyBar,
+            ProgressBar.Params progressBar, RecipeEfficiencyBar.Params efficiencyBar, EnergyBar.Params energyBar,
             // slots
             int itemInputs, int itemOutputs, int fluidInputs, int fluidOutputs, int bucketCapacity,
             Consumer<SlotPositions.Builder> itemSlotPositions, Consumer<SlotPositions.Builder> fluidSlotPositions,
@@ -94,7 +94,7 @@ public class RegisterMachinesEventJS implements KubeEvent, ShapeTemplateHelper {
             String englishName, String internalName, MachineRecipeType recipeType, List<String> tiers,
             // gui
             int backgroundHeight, // can be -1 to use default
-            ProgressBar.Parameters progressBar, RecipeEfficiencyBar.Parameters efficiencyBar, EnergyBar.Parameters energyBar,
+            ProgressBar.Params progressBar, RecipeEfficiencyBar.Params efficiencyBar, EnergyBar.Params energyBar,
             // slots
             int itemInputs, int itemOutputs, int fluidInputs, int fluidOutputs, int bucketCapacity,
             Consumer<SlotPositions.Builder> itemSlotPositions, Consumer<SlotPositions.Builder> fluidSlotPositions,
@@ -142,7 +142,7 @@ public class RegisterMachinesEventJS implements KubeEvent, ShapeTemplateHelper {
             // general
             String englishName, String internalName, MachineRecipeType recipeType, ShapeTemplate multiblockShape,
             // REI parameters
-            ProgressBar.Parameters progressBar,
+            ProgressBar.Params progressBar,
             Consumer<SlotPositions.Builder> itemInputPositions, Consumer<SlotPositions.Builder> itemOutputPositions,
             Consumer<SlotPositions.Builder> fluidInputPositions, Consumer<SlotPositions.Builder> fluidOutputPositions,
             // model
@@ -157,7 +157,7 @@ public class RegisterMachinesEventJS implements KubeEvent, ShapeTemplateHelper {
             // general
             String englishName, String internalName, MachineRecipeType recipeType, ShapeTemplate multiblockShape,
             // REI parameters
-            ProgressBar.Parameters progressBar,
+            ProgressBar.Params progressBar,
             Consumer<SlotPositions.Builder> itemInputPositions, Consumer<SlotPositions.Builder> itemOutputPositions,
             Consumer<SlotPositions.Builder> fluidInputPositions, Consumer<SlotPositions.Builder> fluidOutputPositions,
             // model
@@ -178,7 +178,7 @@ public class RegisterMachinesEventJS implements KubeEvent, ShapeTemplateHelper {
             // general
             String englishName, String internalName, MachineRecipeType recipeType, ShapeTemplate multiblockShape,
             // REI parameters
-            ProgressBar.Parameters progressBar,
+            ProgressBar.Params progressBar,
             Consumer<SlotPositions.Builder> itemInputPositions, Consumer<SlotPositions.Builder> itemOutputPositions,
             Consumer<SlotPositions.Builder> fluidInputPositions, Consumer<SlotPositions.Builder> fluidOutputPositions,
             // model
@@ -193,7 +193,7 @@ public class RegisterMachinesEventJS implements KubeEvent, ShapeTemplateHelper {
             // general
             String englishName, String internalName, MachineRecipeType recipeType, ShapeTemplate multiblockShape,
             // REI parameters
-            ProgressBar.Parameters progressBar,
+            ProgressBar.Params progressBar,
             Consumer<SlotPositions.Builder> itemInputPositions, Consumer<SlotPositions.Builder> itemOutputPositions,
             Consumer<SlotPositions.Builder> fluidInputPositions, Consumer<SlotPositions.Builder> fluidOutputPositions,
             // model
@@ -215,7 +215,7 @@ public class RegisterMachinesEventJS implements KubeEvent, ShapeTemplateHelper {
             // general
             String englishName, String internalName, MachineRecipeType recipeType, ShapeTemplate multiblockShape,
             // REI parameters
-            ProgressBar.Parameters progressBar,
+            ProgressBar.Params progressBar,
             Consumer<SlotPositions.Builder> itemInputPositions, Consumer<SlotPositions.Builder> itemOutputPositions,
             Consumer<SlotPositions.Builder> fluidInputPositions, Consumer<SlotPositions.Builder> fluidOutputPositions,
             // model

--- a/src/main/java/aztech/modern_industrialization/compat/rei/machines/MachineCategoryParams.java
+++ b/src/main/java/aztech/modern_industrialization/compat/rei/machines/MachineCategoryParams.java
@@ -40,7 +40,7 @@ public class MachineCategoryParams {
     public final SlotPositions itemOutputs;
     public final SlotPositions fluidInputs;
     public final SlotPositions fluidOutputs;
-    public final ProgressBar.Parameters progressBarParams;
+    public final ProgressBar.Params progressBarParams;
     public final MachineRecipeType recipeType;
     public final Predicate<MachineRecipe> recipePredicate;
     public final boolean isMultiblock;
@@ -48,7 +48,7 @@ public class MachineCategoryParams {
     public final List<ResourceLocation> workstations = new ArrayList<>();
 
     public MachineCategoryParams(String englishName, ResourceLocation category, SlotPositions itemInputs, SlotPositions itemOutputs,
-            SlotPositions fluidInputs, SlotPositions fluidOutputs, ProgressBar.Parameters progressBarParams, MachineRecipeType recipeType,
+            SlotPositions fluidInputs, SlotPositions fluidOutputs, ProgressBar.Params progressBarParams, MachineRecipeType recipeType,
             Predicate<MachineRecipe> recipePredicate, boolean isMultiblock, SteamMode steamMode) {
         this.englishName = englishName;
         this.category = category;

--- a/src/main/java/aztech/modern_industrialization/machines/ComponentStorage.java
+++ b/src/main/java/aztech/modern_industrialization/machines/ComponentStorage.java
@@ -24,7 +24,7 @@
 
 package aztech.modern_industrialization.machines;
 
-import aztech.modern_industrialization.machines.gui.GuiComponent;
+import aztech.modern_industrialization.machines.gui.GuiComponentServer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import net.minecraft.resources.ResourceLocation;
 import org.jspecify.annotations.Nullable;
 
 public sealed class ComponentStorage<C> implements Iterable<C> permits ComponentStorage.GuiServer, ComponentStorage.Server {
@@ -70,13 +69,21 @@ public sealed class ComponentStorage<C> implements Iterable<C> permits Component
     }
 
     @Nullable
-    public final <T> T get(Class<T> clazz) {
+    public final <T> T getNullable(Class<T> clazz) {
         for (C component : components) {
             if (clazz.isInstance(component)) {
                 return (T) component;
             }
         }
         return null;
+    }
+
+    public final <T> T getOrThrow(Class<T> clazz) {
+        T ret = getNullable(clazz);
+        if (ret == null) {
+            throw new RuntimeException("Component not found: " + clazz);
+        }
+        return ret;
     }
 
     public final <T> List<T> getAll(Class<T> clazz) {
@@ -107,19 +114,7 @@ public sealed class ComponentStorage<C> implements Iterable<C> permits Component
         }
     }
 
-    public static final class GuiServer extends ComponentStorage<GuiComponent.Server> {
-        /**
-         * @throws RuntimeException if the component doesn't exist.
-         */
-        public <S extends GuiComponent.Server> S get(ResourceLocation componentId) {
-            for (GuiComponent.Server component : components) {
-                if (component.getId().equals(componentId)) {
-                    return (S) component;
-                }
-            }
-            throw new RuntimeException("Couldn't find component " + componentId);
-        }
-    }
+    public static final class GuiServer extends ComponentStorage<GuiComponentServer<?, ?>> {}
 
     public static final class Server extends ComponentStorage<IComponent> {}
 }

--- a/src/main/java/aztech/modern_industrialization/machines/MachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/MachineBlockEntity.java
@@ -31,7 +31,7 @@ import aztech.modern_industrialization.inventory.MIInventory;
 import aztech.modern_industrialization.machines.components.DropableComponent;
 import aztech.modern_industrialization.machines.components.OrientationComponent;
 import aztech.modern_industrialization.machines.components.PlacedByComponent;
-import aztech.modern_industrialization.machines.gui.GuiComponent;
+import aztech.modern_industrialization.machines.gui.GuiComponentServer;
 import aztech.modern_industrialization.machines.gui.MachineGuiParameters;
 import aztech.modern_industrialization.machines.gui.MachineMenuServer;
 import aztech.modern_industrialization.machines.models.MachineModelClientData;
@@ -98,7 +98,7 @@ public abstract class MachineBlockEntity extends FastBlockEntity
         registerComponents(orientation, placedBy);
     }
 
-    protected final void registerGuiComponent(GuiComponent.Server... components) {
+    protected final void registerGuiComponent(GuiComponentServer... components) {
         guiComponents.register(components);
     }
 
@@ -133,12 +133,18 @@ public abstract class MachineBlockEntity extends FastBlockEntity
         inv.fluidPositions.write(buf);
         buf.writeInt(guiComponents.size());
         // Write components
-        for (GuiComponent.Server component : guiComponents) {
-            buf.writeResourceLocation(component.getId());
-            component.writeInitialData(buf);
+        for (GuiComponentServer<?, ?> component : guiComponents) {
+            writeInitialGuiComponent(buf, component);
         }
         // Write GUI params
         guiParams.write(buf);
+    }
+
+    private static <P, D> void writeInitialGuiComponent(RegistryFriendlyByteBuf buf, GuiComponentServer<P, D> component) {
+        var type = component.getType();
+        buf.writeResourceLocation(type.id());
+        type.paramsCodec().encode(buf, component.getParams());
+        type.dataCodec().encode(buf, component.extractData());
     }
 
     /**

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/AbstractCraftingMachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/AbstractCraftingMachineBlockEntity.java
@@ -46,16 +46,16 @@ import org.jspecify.annotations.Nullable;
 public abstract class AbstractCraftingMachineBlockEntity extends MachineBlockEntity implements CrafterComponent.Behavior, Tickable,
         CrafterComponentHolder {
     public AbstractCraftingMachineBlockEntity(BEP bep, MachineRecipeType recipeType, MachineInventoryComponent inventory,
-            MachineGuiParameters guiParams, ProgressBar.Parameters progressBarParams, MachineTier tier) {
+            MachineGuiParameters guiParams, ProgressBar.Params progressBarParams, MachineTier tier) {
         super(bep, guiParams, new OrientationComponent.Params(true, inventory.itemOutputCount > 0, inventory.fluidOutputCount > 0));
         this.inventory = inventory;
         this.crafter = new CrafterComponent(this, inventory, this);
         this.type = recipeType;
         this.tier = tier;
         this.isActiveComponent = new IsActiveComponent();
-        registerGuiComponent(new AutoExtract.Server(orientation));
-        registerGuiComponent(new ProgressBar.Server(progressBarParams, crafter::getProgress));
-        registerGuiComponent(new ReiSlotLocking.Server(crafter::lockRecipe, () -> true));
+        registerGuiComponent(new AutoExtract(orientation));
+        registerGuiComponent(new ProgressBar(progressBarParams, crafter::getProgress));
+        registerGuiComponent(new ReiSlotLocking(crafter::lockRecipe, () -> true));
         this.registerComponents(crafter, this.inventory, isActiveComponent);
     }
 

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/AbstractStorageMachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/AbstractStorageMachineBlockEntity.java
@@ -82,9 +82,9 @@ public abstract class AbstractStorageMachineBlockEntity extends MachineBlockEnti
 
         this.registerComponents(energy, redstoneControl);
 
-        EnergyBar.Parameters energyBarParams = new EnergyBar.Parameters(76, 39);
-        registerGuiComponent(new EnergyBar.Server(energyBarParams, energy::getEu, energy::getCapacity),
-                new SlotPanel.Server(this).withRedstoneControl(redstoneControl));
+        EnergyBar.Params energyBarParams = new EnergyBar.Params(76, 39);
+        registerGuiComponent(new EnergyBar(energyBarParams, energy::getEu, energy::getCapacity),
+                new SlotPanel(this).withRedstoneControl(redstoneControl));
 
         this.extractableOnOutputDirection = extractableOnOutputDirection;
     }

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/AbstractWaterPumpBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/AbstractWaterPumpBlockEntity.java
@@ -45,14 +45,14 @@ import net.neoforged.neoforge.fluids.FluidType;
 public abstract class AbstractWaterPumpBlockEntity extends MachineBlockEntity implements Tickable {
     protected static final int OUTPUT_SLOT_X = 110;
     protected static final int OUTPUT_SLOT_Y = 30;
-    private static final ProgressBar.Parameters PROGRESS_BAR = new ProgressBar.Parameters(79, 29, "extract");
+    private static final ProgressBar.Params PROGRESS_BAR = new ProgressBar.Params(79, 29, "extract");
     private static final int OPERATION_TICKS = 100;
 
     public AbstractWaterPumpBlockEntity(BEP bep, String blockName) {
         super(bep, new MachineGuiParameters.Builder(blockName, false).build(), new OrientationComponent.Params(true, false, false));
 
         isActiveComponent = new IsActiveComponent();
-        registerGuiComponent(new ProgressBar.Server(PROGRESS_BAR, () -> (float) pumpingTicks / OPERATION_TICKS));
+        registerGuiComponent(new ProgressBar(PROGRESS_BAR, () -> (float) pumpingTicks / OPERATION_TICKS));
         this.registerComponents(isActiveComponent, new IComponent() {
             @Override
             public void writeNbt(CompoundTag tag, HolderLookup.Provider registries) {

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/BoilerMachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/BoilerMachineBlockEntity.java
@@ -89,10 +89,10 @@ public class BoilerMachineBlockEntity extends MachineBlockEntity implements Tick
         fuelBurning = new FuelBurningComponent(steamHeater, 1);
         this.isActiveComponent = new IsActiveComponent();
 
-        ProgressBar.Parameters progressParams = new ProgressBar.Parameters(133, 50, "furnace", 14, 14, true);
-        TemperatureBar.Parameters temperatureParams = new TemperatureBar.Parameters(42, 75, 1500);
-        registerGuiComponent(new ProgressBar.Server(progressParams, () -> (float) fuelBurning.getBurningProgress()));
-        registerGuiComponent(new TemperatureBar.Server(temperatureParams, () -> (int) steamHeater.getTemperature()));
+        ProgressBar.Params progressParams = new ProgressBar.Params(133, 50, "furnace", 14, 14, true);
+        TemperatureBar.Params temperatureParams = new TemperatureBar.Params(42, 75, 1500);
+        registerGuiComponent(new ProgressBar(progressParams, () -> (float) fuelBurning.getBurningProgress()));
+        registerGuiComponent(new TemperatureBar(temperatureParams, () -> (int) steamHeater.getTemperature()));
 
         this.registerComponents(inventory, isActiveComponent, steamHeater, fuelBurning);
     }

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/ConfigurableChestMachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/ConfigurableChestMachineBlockEntity.java
@@ -53,7 +53,7 @@ public class ConfigurableChestMachineBlockEntity extends MachineBlockEntity impl
         SlotPositions itemPositions = new SlotPositions.Builder().addSlots(8, 30, 9, 3).build();
         inventory = new MIInventory(stacks, Collections.emptyList(), itemPositions, SlotPositions.empty());
 
-        registerGuiComponent(new AutoExtract.Server(orientation));
+        registerGuiComponent(new AutoExtract(orientation));
         registerComponents(inventory);
     }
 

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/ConfigurableTankMachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/ConfigurableTankMachineBlockEntity.java
@@ -54,7 +54,7 @@ public class ConfigurableTankMachineBlockEntity extends MachineBlockEntity imple
         SlotPositions fluidPositions = new SlotPositions.Builder().addSlots(68, 20, 3, 3).build();
         inventory = new MIInventory(Collections.emptyList(), stacks, SlotPositions.empty(), fluidPositions);
 
-        registerGuiComponent(new AutoExtract.Server(orientation));
+        registerGuiComponent(new AutoExtract(orientation));
         registerComponents(inventory);
     }
 

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/ElectricCraftingMachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/ElectricCraftingMachineBlockEntity.java
@@ -49,8 +49,8 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 
 public class ElectricCraftingMachineBlockEntity extends AbstractCraftingMachineBlockEntity implements EnergyComponentHolder, CableTierHolder {
     public ElectricCraftingMachineBlockEntity(BEP bep, MachineRecipeType recipeType, MachineInventoryComponent inventory,
-            MachineGuiParameters guiParams, EnergyBar.Parameters energyBarParams, ProgressBar.Parameters progressBarParams,
-            RecipeEfficiencyBar.Parameters efficiencyBarParams, MachineTier tier, long euCapacity) {
+            MachineGuiParameters guiParams, EnergyBar.Params energyBarParams, ProgressBar.Params progressBarParams,
+            RecipeEfficiencyBar.Params efficiencyBarParams, MachineTier tier, long euCapacity) {
         super(bep, recipeType, inventory, guiParams, progressBarParams, tier);
         this.redstoneControl = new RedstoneControlComponent();
         this.casing = new CasingComponent();
@@ -58,9 +58,9 @@ public class ElectricCraftingMachineBlockEntity extends AbstractCraftingMachineB
         this.overdrive = new OverdriveComponent();
         this.energy = new EnergyComponent(this, casing::getEuCapacity);
         this.insertable = energy.buildInsertable(cableTier -> this.casing.canInsertEu(cableTier));
-        registerGuiComponent(new EnergyBar.Server(energyBarParams, energy::getEu, energy::getCapacity));
-        registerGuiComponent(new RecipeEfficiencyBar.Server(efficiencyBarParams, crafter));
-        registerGuiComponent(new SlotPanel.Server(this)
+        registerGuiComponent(new EnergyBar(energyBarParams, energy::getEu, energy::getCapacity));
+        registerGuiComponent(new RecipeEfficiencyBar(efficiencyBarParams, crafter));
+        registerGuiComponent(new SlotPanel(this)
                 .withRedstoneControl(redstoneControl)
                 .withUpgrades(upgrades)
                 .withCasing(casing)

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/ElectricWaterPumpBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/ElectricWaterPumpBlockEntity.java
@@ -65,8 +65,8 @@ public class ElectricWaterPumpBlockEntity extends AbstractWaterPumpBlockEntity i
 
         this.registerComponents(inventory, redstoneControl, casing, energy);
 
-        registerGuiComponent(new EnergyBar.Server(new EnergyBar.Parameters(18, 32), energy::getEu, energy::getCapacity));
-        registerGuiComponent(new SlotPanel.Server(this)
+        registerGuiComponent(new EnergyBar(new EnergyBar.Params(18, 32), energy::getEu, energy::getCapacity));
+        registerGuiComponent(new SlotPanel(this)
                 .withRedstoneControl(redstoneControl)
                 .withCasing(casing));
     }

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/GeneratorMachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/GeneratorMachineBlockEntity.java
@@ -79,8 +79,8 @@ public class GeneratorMachineBlockEntity extends MachineBlockEntity implements T
         this.fluidItemConsumer = fluidItemConsumer;
         this.redstoneControl = new RedstoneControlComponent();
 
-        EnergyBar.Parameters energyBarParams = new EnergyBar.Parameters(76, 39);
-        registerGuiComponent(new EnergyBar.Server(energyBarParams, energy::getEu, energy::getCapacity));
+        EnergyBar.Params energyBarParams = new EnergyBar.Params(76, 39);
+        registerGuiComponent(new EnergyBar(energyBarParams, energy::getEu, energy::getCapacity));
 
         List<ConfigurableItemStack> itemStacks;
         List<ConfigurableFluidStack> fluidStacks;
@@ -138,7 +138,7 @@ public class GeneratorMachineBlockEntity extends MachineBlockEntity implements T
         inventory = new MIInventory(itemStacks, fluidStacks, itemPositions, fluidPositions);
 
         this.registerComponents(energy, isActiveComponent, inventory, fluidItemConsumer, redstoneControl);
-        this.registerGuiComponent(new SlotPanel.Server(this).withRedstoneControl(redstoneControl));
+        this.registerGuiComponent(new SlotPanel(this).withRedstoneControl(redstoneControl));
     }
 
     public GeneratorMachineBlockEntity(BEP bep,

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/ReplicatorMachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/ReplicatorMachineBlockEntity.java
@@ -70,7 +70,7 @@ public class ReplicatorMachineBlockEntity extends MachineBlockEntity implements 
 
         this.isActiveComponent = new IsActiveComponent();
         this.redstoneControl = new RedstoneControlComponent();
-        ProgressBar.Parameters progressBarParams = new ProgressBar.Parameters(85, 34, "arrow");
+        ProgressBar.Params progressBarParams = new ProgressBar.Params(85, 34, "arrow");
 
         long capacity = FluidType.BUCKET_VOLUME * 256;
 
@@ -97,9 +97,9 @@ public class ReplicatorMachineBlockEntity extends MachineBlockEntity implements 
             }
         });
 
-        registerGuiComponent(new ProgressBar.Server(progressBarParams, () -> (float) progressTick / 20));
-        registerGuiComponent(new AutoExtract.Server(orientation, false));
-        registerGuiComponent(new SlotPanel.Server(this).withRedstoneControl(redstoneControl));
+        registerGuiComponent(new ProgressBar(progressBarParams, () -> (float) progressTick / 20));
+        registerGuiComponent(new AutoExtract(orientation, false));
+        registerGuiComponent(new SlotPanel(this).withRedstoneControl(redstoneControl));
     }
 
     @Override

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/SteamCraftingMachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/SteamCraftingMachineBlockEntity.java
@@ -46,13 +46,13 @@ public class SteamCraftingMachineBlockEntity extends AbstractCraftingMachineBloc
     private final OverclockComponent overclockComponent;
 
     public SteamCraftingMachineBlockEntity(BEP bep, MachineRecipeType recipeType, MachineInventoryComponent inventory, MachineGuiParameters guiParams,
-            ProgressBar.Parameters progressBarParams, MachineTier tier, List<OverclockComponent.Catalyst> overclockCatalysts) {
+            ProgressBar.Params progressBarParams, MachineTier tier, List<OverclockComponent.Catalyst> overclockCatalysts) {
         super(bep, recipeType, inventory, guiParams, progressBarParams, tier);
         this.overclockComponent = new OverclockComponent(overclockCatalysts);
 
-        GunpowderOverclockGui.Parameters gunpowderOverclockGuiParams = new GunpowderOverclockGui.Parameters(progressBarParams.renderX,
-                progressBarParams.renderY + 20);
-        registerGuiComponent(new GunpowderOverclockGui.Server(gunpowderOverclockGuiParams, overclockComponent::getTicks));
+        GunpowderOverclockGui.Params gunpowderOverclockGuiParams = new GunpowderOverclockGui.Params(progressBarParams.renderX(),
+                progressBarParams.renderY() + 20);
+        registerGuiComponent(new GunpowderOverclockGui(gunpowderOverclockGuiParams, overclockComponent::getTicks));
         this.registerComponents(overclockComponent);
     }
 

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/EnergyHatch.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/EnergyHatch.java
@@ -53,8 +53,8 @@ public class EnergyHatch extends HatchBlockEntity implements EnergyComponentHold
         this.energy = new EnergyComponent(this, 30 * 20 * tier.getEu());
         insertable = energy.buildInsertable((CableTier tier2) -> tier2 == tier);
         extractable = energy.buildExtractable((CableTier tier2) -> tier2 == tier);
-        EnergyBar.Parameters energyBarParams = new EnergyBar.Parameters(76, 39);
-        registerGuiComponent(new EnergyBar.Server(energyBarParams, energy::getEu, energy::getCapacity));
+        EnergyBar.Params energyBarParams = new EnergyBar.Params(76, 39);
+        registerGuiComponent(new EnergyBar(energyBarParams, energy::getEu, energy::getCapacity));
 
         this.registerComponents(energy);
     }

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/FluidHatch.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/FluidHatch.java
@@ -48,7 +48,7 @@ public class FluidHatch extends HatchBlockEntity {
         this.inventory = inventory;
 
         registerComponents(inventory);
-        registerGuiComponent(new AutoExtract.Server(orientation, input));
+        registerGuiComponent(new AutoExtract(orientation, input));
     }
 
     private final boolean input;

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/ItemHatch.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/ItemHatch.java
@@ -47,7 +47,7 @@ public class ItemHatch extends HatchBlockEntity {
         this.inventory = inventory;
 
         registerComponents(inventory);
-        registerGuiComponent(new AutoExtract.Server(orientation, input));
+        registerGuiComponent(new AutoExtract(orientation, input));
     }
 
     private final boolean input;

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/NuclearHatch.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/NuclearHatch.java
@@ -92,8 +92,8 @@ public class NuclearHatch extends HatchBlockEntity implements INuclearTile {
         neutronHistory = new NeutronHistoryComponent();
         registerComponents(inventory, nuclearReactorComponent, neutronHistory);
 
-        TemperatureBar.Parameters temperatureParams = new TemperatureBar.Parameters(43, 63, NuclearConstant.MAX_TEMPERATURE);
-        registerGuiComponent(new TemperatureBar.Server(temperatureParams, () -> (int) nuclearReactorComponent.getTemperature()));
+        TemperatureBar.Params temperatureParams = new TemperatureBar.Params(43, 63, NuclearConstant.MAX_TEMPERATURE);
+        registerGuiComponent(new TemperatureBar(temperatureParams, () -> (int) nuclearReactorComponent.getTemperature()));
     }
 
     @Override

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/AbstractCraftingMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/AbstractCraftingMultiblockBlockEntity.java
@@ -49,7 +49,7 @@ public abstract class AbstractCraftingMultiblockBlockEntity extends MultiblockMa
         this.inventory = new MultiblockInventoryComponent();
         this.crafter = new CrafterComponent(this, inventory, getBehavior());
         this.isActive = new IsActiveComponent();
-        registerGuiComponent(new ReiSlotLocking.Server(crafter::lockRecipe, () -> operatingState != OperatingState.NOT_MATCHED));
+        registerGuiComponent(new ReiSlotLocking(crafter::lockRecipe, () -> operatingState != OperatingState.NOT_MATCHED));
         registerComponents(activeShape, crafter, isActive);
     }
 

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/AbstractElectricCraftingMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/AbstractElectricCraftingMultiblockBlockEntity.java
@@ -52,7 +52,7 @@ public abstract class AbstractElectricCraftingMultiblockBlockEntity extends Abst
         super(bep, blockId, orientationParams, shapeTemplates);
 
         this.redstoneControl = new RedstoneControlComponent();
-        registerGuiComponent(new CraftingMultiblockGui.Server(() -> shapeValid.shapeValid, crafter::getProgress, crafter, () -> 0));
+        registerGuiComponent(new CraftingMultiblockGui(() -> shapeValid.shapeValid, crafter::getProgress, crafter, () -> 0));
         registerComponents(redstoneControl);
     }
 

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/DistillationTowerBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/DistillationTowerBlockEntity.java
@@ -40,6 +40,7 @@ import aztech.modern_industrialization.machines.models.MachineCasings;
 import aztech.modern_industrialization.machines.multiblocks.*;
 import aztech.modern_industrialization.machines.recipe.MachineRecipeType;
 import java.util.stream.IntStream;
+import net.minecraft.network.chat.Component;
 
 public class DistillationTowerBlockEntity extends AbstractElectricCraftingMultiblockBlockEntity implements EnergyListComponentHolder {
     private static final int MAX_HEIGHT = MIStartupConfig.INSTANCE.maxDistillationTowerHeight.getAsInt();
@@ -50,12 +51,12 @@ public class DistillationTowerBlockEntity extends AbstractElectricCraftingMultib
         this.upgrades = new UpgradeComponent();
         this.overdrive = new OverdriveComponent();
         this.registerComponents(upgrades, overdrive);
-        registerGuiComponent(new SlotPanel.Server(this)
+        registerGuiComponent(new SlotPanel(this)
                 .withRedstoneControl(redstoneControl)
                 .withUpgrades(upgrades)
                 .withOverdrive(overdrive));
 
-        registerGuiComponent(new ShapeSelection.Server(new ShapeSelection.Behavior() {
+        registerGuiComponent(new ShapeSelection(new ShapeSelection.Behavior() {
             @Override
             public void handleClick(int clickedLine, int delta) {
                 activeShape.incrementShape(DistillationTowerBlockEntity.this, delta);
@@ -66,8 +67,7 @@ public class DistillationTowerBlockEntity extends AbstractElectricCraftingMultib
                 return activeShape.getActiveShapeIndex();
             }
         }, new ShapeSelection.LineInfo(
-                MAX_HEIGHT,
-                IntStream.range(1, MAX_HEIGHT + 1).mapToObj(MIText.ShapeTextHeight::text).toList(),
+                IntStream.range(1, MAX_HEIGHT + 1).<Component>mapToObj(MIText.ShapeTextHeight::text).toList(),
                 false)));
     }
 

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/ElectricBlastFurnaceBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/ElectricBlastFurnaceBlockEntity.java
@@ -112,14 +112,14 @@ public class ElectricBlastFurnaceBlockEntity extends AbstractElectricCraftingMul
         this.upgrades = new UpgradeComponent();
         this.overdrive = new OverdriveComponent();
         this.registerComponents(upgrades, overdrive);
-        registerGuiComponent(new SlotPanel.Server(this)
+        registerGuiComponent(new SlotPanel(this)
                 .withRedstoneControl(redstoneControl)
                 .withUpgrades(upgrades)
                 .withOverdrive(overdrive));
 
         var tierComponents = tiers.stream().map(Tier::getDisplayName).toList();
 
-        registerGuiComponent(new ShapeSelection.Server(new ShapeSelection.Behavior() {
+        registerGuiComponent(new ShapeSelection(new ShapeSelection.Behavior() {
             @Override
             public void handleClick(int clickedLine, int delta) {
                 activeShape.incrementShape(ElectricBlastFurnaceBlockEntity.this, delta);
@@ -129,7 +129,7 @@ public class ElectricBlastFurnaceBlockEntity extends AbstractElectricCraftingMul
             public int getCurrentIndex(int line) {
                 return activeShape.getActiveShapeIndex();
             }
-        }, new ShapeSelection.LineInfo(tiers.size(), tierComponents, true)));
+        }, new ShapeSelection.LineInfo(tierComponents, true)));
     }
 
     private final UpgradeComponent upgrades;

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/ElectricCraftingMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/ElectricCraftingMultiblockBlockEntity.java
@@ -42,7 +42,7 @@ public class ElectricCraftingMultiblockBlockEntity extends AbstractElectricCraft
         this.upgrades = new UpgradeComponent();
         this.overdrive = new OverdriveComponent();
         this.registerComponents(upgrades, overdrive);
-        registerGuiComponent(new SlotPanel.Server(this)
+        registerGuiComponent(new SlotPanel(this)
                 .withRedstoneControl(redstoneControl)
                 .withUpgrades(upgrades)
                 .withOverdrive(overdrive));

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/FusionReactorBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/FusionReactorBlockEntity.java
@@ -36,7 +36,7 @@ public class FusionReactorBlockEntity extends AbstractElectricCraftingMultiblock
     public FusionReactorBlockEntity(BEP bep, String name, ShapeTemplate shapeTemplate) {
         super(bep, name, new OrientationComponent.Params(false, false, false), new ShapeTemplate[] { shapeTemplate });
 
-        registerGuiComponent(new SlotPanel.Server(this).withRedstoneControl(redstoneControl));
+        registerGuiComponent(new SlotPanel(this).withRedstoneControl(redstoneControl));
     }
 
     @Override

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/GeneratorMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/GeneratorMultiblockBlockEntity.java
@@ -59,7 +59,7 @@ public class GeneratorMultiblockBlockEntity extends MultiblockMachineBlockEntity
         this.redstoneControl = new RedstoneControlComponent();
 
         this.registerComponents(activeShape, isActiveComponent, fluidConsumer, redstoneControl);
-        registerGuiComponent(new SlotPanel.Server(this).withRedstoneControl(redstoneControl));
+        registerGuiComponent(new SlotPanel(this).withRedstoneControl(redstoneControl));
     }
 
     private boolean allowNormalOperation = false;

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/LargeTankMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/LargeTankMultiblockBlockEntity.java
@@ -79,8 +79,7 @@ public class LargeTankMultiblockBlockEntity extends MultiblockMachineBlockEntity
 
     private static ShapeSelection.LineInfo createLineInfo(int[] sizes, MIText baseText) {
         return new ShapeSelection.LineInfo(
-                sizes.length,
-                IntStream.of(sizes).mapToObj(baseText::text).toList(),
+                IntStream.of(sizes).<Component>mapToObj(baseText::text).toList(),
                 false);
     }
 
@@ -156,7 +155,7 @@ public class LargeTankMultiblockBlockEntity extends MultiblockMachineBlockEntity
 
         this.registerComponents(activeShape, fluidStorage);
 
-        this.registerGuiComponent(new ShapeSelection.Server(new ShapeSelection.Behavior() {
+        this.registerGuiComponent(new ShapeSelection(new ShapeSelection.Behavior() {
             @Override
             public void handleClick(int clickedLine, int delta) {
                 int shape = activeShape.getActiveShapeIndex();
@@ -190,7 +189,7 @@ public class LargeTankMultiblockBlockEntity extends MultiblockMachineBlockEntity
         }, createLineInfo(X_SIZES, MIText.ShapeTextWidth), createLineInfo(Y_SIZES, MIText.ShapeTextHeight),
                 createLineInfo(Z_SIZES, MIText.ShapeTextDepth)));
         // Must be after shape selection because we render text in the selection panel
-        this.registerGuiComponent(new LargeTankFluidDisplay.Server(this::getFluidData));
+        this.registerGuiComponent(new LargeTankFluidDisplay(this::getFluidData));
     }
 
     public LargeTankFluidDisplay.Data getFluidData() {

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/NuclearReactorMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/NuclearReactorMultiblockBlockEntity.java
@@ -41,6 +41,7 @@ import aztech.modern_industrialization.machines.models.MachineModelClientData;
 import aztech.modern_industrialization.machines.multiblocks.*;
 import aztech.modern_industrialization.nuclear.*;
 import aztech.modern_industrialization.util.Tickable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -71,9 +72,9 @@ public class NuclearReactorMultiblockBlockEntity extends MultiblockMachineBlockE
         this.isActive = new IsActiveComponent();
         this.redstoneControl = new RedstoneControlComponent();
         registerComponents(activeShape, isActive, efficiencyHistory, redstoneControl);
-        this.registerGuiComponent(new NuclearReactorGui.Server(this::sendData), new SlotPanel.Server(this).withRedstoneControl(redstoneControl));
+        this.registerGuiComponent(new NuclearReactorGui(this::sendData), new SlotPanel(this).withRedstoneControl(redstoneControl));
 
-        registerGuiComponent(new ShapeSelection.Server(new ShapeSelection.Behavior() {
+        registerGuiComponent(new ShapeSelection(new ShapeSelection.Behavior() {
             @Override
             public void handleClick(int clickedLine, int delta) {
                 activeShape.incrementShape(NuclearReactorMultiblockBlockEntity.this, delta);
@@ -84,7 +85,7 @@ public class NuclearReactorMultiblockBlockEntity extends MultiblockMachineBlockE
                 return activeShape.getActiveShapeIndex();
             }
         }, new ShapeSelection.LineInfo(
-                4, List.of(MIText.ShapeTextSmall.text(), MIText.ShapeTextMedium.text(), MIText.ShapeTextLarge.text(), MIText.ShapeTextExtreme.text()),
+                List.of(MIText.ShapeTextSmall.text(), MIText.ShapeTextMedium.text(), MIText.ShapeTextLarge.text(), MIText.ShapeTextExtreme.text()),
                 true)));
     }
 
@@ -169,15 +170,13 @@ public class NuclearReactorMultiblockBlockEntity extends MultiblockMachineBlockE
             nuclearGrid = new NuclearGrid(size, size, hatchesGrid);
 
             dataSupplier = () -> {
-                Optional<INuclearTileData>[] tilesData = new Optional[size * size];
+                List<NuclearReactorGui.TileData> tilesData = new ArrayList<>(size * size);
                 for (int i = 0; i < size; i++) {
                     for (int j = 0; j < size; j++) {
-
                         final int x = size - 1 - i;
                         final int y = size - 1 - j;
 
-                        int index = NuclearReactorGui.Data.toIndex(i, j, size);
-                        tilesData[index] = Optional.ofNullable(hatchesGrid[x][y]);
+                        tilesData.add(new NuclearReactorGui.TileData(Optional.ofNullable(hatchesGrid[x][y])));
                     }
                 }
                 return new NuclearReactorGui.Data(true, size, size, tilesData,

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/SteamBoilerMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/SteamBoilerMultiblockBlockEntity.java
@@ -71,12 +71,12 @@ public class SteamBoilerMultiblockBlockEntity extends MultiblockMachineBlockEnti
 
         this.registerComponents(isActiveComponent, steamHeater, fuelBurning, redstoneControl);
 
-        ProgressBar.Parameters PROGRESS_BAR = new ProgressBar.Parameters(82, 30, "furnace", 14, 14, true);
-        TemperatureBar.Parameters TEMPERATURE_BAR = new TemperatureBar.Parameters(42, 55, 2500);
+        ProgressBar.Params PROGRESS_BAR = new ProgressBar.Params(82, 30, "furnace", 14, 14, true);
+        TemperatureBar.Params TEMPERATURE_BAR = new TemperatureBar.Params(42, 55, 2500);
 
-        registerGuiComponent(new ProgressBar.Server(PROGRESS_BAR, () -> (float) fuelBurning.getBurningProgress()));
-        registerGuiComponent(new TemperatureBar.Server(TEMPERATURE_BAR, () -> (int) steamHeater.getTemperature()));
-        registerGuiComponent(new SlotPanel.Server(this).withRedstoneControl(redstoneControl));
+        registerGuiComponent(new ProgressBar(PROGRESS_BAR, () -> (float) fuelBurning.getBurningProgress()));
+        registerGuiComponent(new TemperatureBar(TEMPERATURE_BAR, () -> (int) steamHeater.getTemperature()));
+        registerGuiComponent(new SlotPanel(this).withRedstoneControl(redstoneControl));
     }
 
     @Override

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/SteamCraftingMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/SteamCraftingMultiblockBlockEntity.java
@@ -58,7 +58,7 @@ public class SteamCraftingMultiblockBlockEntity extends AbstractCraftingMultiblo
         this.overclockComponent = new OverclockComponent(overclockCatalysts);
         this.recipeType = recipeType;
         registerGuiComponent(
-                new CraftingMultiblockGui.Server(() -> shapeValid.shapeValid, crafter::getProgress, crafter, overclockComponent::getTicks));
+                new CraftingMultiblockGui(() -> shapeValid.shapeValid, crafter::getProgress, crafter, overclockComponent::getTicks));
         this.registerComponents(overclockComponent);
     }
 

--- a/src/main/java/aztech/modern_industrialization/machines/gui/GuiComponent.java
+++ b/src/main/java/aztech/modern_industrialization/machines/gui/GuiComponent.java
@@ -25,73 +25,17 @@
 package aztech.modern_industrialization.machines.gui;
 
 import aztech.modern_industrialization.inventory.SlotGroup;
-import net.minecraft.network.RegistryFriendlyByteBuf;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.Unit;
 import net.minecraft.world.inventory.Slot;
 
-public final class GuiComponent {
-    public interface MenuFacade {
+/**
+ * Common class for the client and the server side of gui components.
+ */
+public interface GuiComponent {
+    default void setupMenu(MenuFacade menu) {}
+
+    interface MenuFacade {
         void addSlotToMenu(Slot slot, SlotGroup slotGroup);
 
         MachineGuiParameters getGuiParams();
-    }
-
-    public interface Common {
-        default void setupMenu(MenuFacade menu) {}
-    }
-
-    /**
-     * Server part of a synced component.
-     *
-     * @param <D> Synced data type.
-     */
-    public interface Server<D> extends Common {
-        /**
-         * @return A copy of the current sync data.
-         */
-        D copyData();
-
-        /**
-         * @return Whether the cached data is outdated, meaning that a sync must be
-         *         performed.
-         */
-        boolean needsSync(D cachedData);
-
-        /**
-         * Write the initial data to the packet byte buf, used only when the screen is
-         * opened.
-         */
-        void writeInitialData(RegistryFriendlyByteBuf buf);
-
-        /**
-         * Write the current data to the packet byte buf, used when syncing after the
-         * screen was opened.
-         */
-        void writeCurrentData(RegistryFriendlyByteBuf buf);
-
-        /**
-         * Return the id of the component. Must match that of the {@code GuiComponentClient}
-         * registered with {@code GuiComponentsClient#register}.
-         */
-        ResourceLocation getId();
-    }
-
-    /**
-     * Convenience override when no data needs to be synced.
-     */
-    public interface ServerNoData extends Server<Unit> {
-        @Override
-        default Unit copyData() {
-            return Unit.INSTANCE;
-        }
-
-        @Override
-        default boolean needsSync(Unit cachedData) {
-            return false;
-        }
-
-        @Override
-        default void writeCurrentData(RegistryFriendlyByteBuf buf) {}
     }
 }

--- a/src/main/java/aztech/modern_industrialization/machines/gui/GuiComponentServer.java
+++ b/src/main/java/aztech/modern_industrialization/machines/gui/GuiComponentServer.java
@@ -22,22 +22,34 @@
  * SOFTWARE.
  */
 
-package aztech.modern_industrialization.machines;
+package aztech.modern_industrialization.machines.gui;
 
-import aztech.modern_industrialization.MI;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.ResourceLocation;
 
-public final class GuiComponents {
-    public static final ResourceLocation AUTO_EXTRACT = MI.id("auto_extract");
-    public static final ResourceLocation CRAFTING_MULTIBLOCK_GUI = MI.id("crafting_multiblock_gui");
-    public static final ResourceLocation ENERGY_BAR = MI.id("energy_bar");
-    public static final ResourceLocation LARGE_TANK_FLUID_DISPLAY = MI.id("large_tank_fluid_display");
-    public static final ResourceLocation GUNPOWDER_OVERCLOCK_GUI = MI.id("gunpowder_overclock_gui");
-    public static final ResourceLocation NUCLEAR_REACTOR_GUI = MI.id("nuclear_reactor_gui");
-    public static final ResourceLocation PROGRESS_BAR = MI.id("progress_bar");
-    public static final ResourceLocation RECIPE_EFFICIENCY_BAR = MI.id("recipe_efficiency_bar");
-    public static final ResourceLocation REI_SLOT_LOCKING = MI.id("rei_slot_locking");
-    public static final ResourceLocation SHAPE_SELECTION = MI.id("shape_selection");
-    public static final ResourceLocation SLOT_PANEL = MI.id("slot_panel");
-    public static final ResourceLocation TEMPERATURE_BAR = MI.id("temperature_bar");
+/**
+ * Server part of a synced component.
+ *
+ * @param <P> Parameters, synced to the client when the menu is opened.
+ * @param <D> Data synced to the client when the menu is opened and when it changes. Must be equals-comparable.
+ */
+public interface GuiComponentServer<P, D> extends GuiComponent {
+    P getParams();
+
+    /**
+     * Extracts the syncable data from the state of the component, block entity, etc.
+     */
+    D extractData();
+
+    /**
+     * Return the id of the component. Must match that of the {@code GuiComponentClient}
+     * registered with {@code GuiComponentsClient#register}.
+     */
+    Type<P, D> getType();
+
+    record Type<P, D>(
+            ResourceLocation id,
+            StreamCodec<? super RegistryFriendlyByteBuf, P> paramsCodec,
+            StreamCodec<? super RegistryFriendlyByteBuf, D> dataCodec) {}
 }

--- a/src/main/java/aztech/modern_industrialization/machines/gui/MachineMenuCommon.java
+++ b/src/main/java/aztech/modern_industrialization/machines/gui/MachineMenuCommon.java
@@ -39,7 +39,7 @@ public abstract class MachineMenuCommon extends ConfigurableScreenHandler implem
     public final MachineGuiParameters guiParams;
 
     MachineMenuCommon(int syncId, Inventory playerInventory, MIInventory inventory, MachineGuiParameters guiParams,
-            ComponentStorage<? extends GuiComponent.Common> guiComponents) {
+            ComponentStorage<? extends GuiComponent> guiComponents) {
         super(MIRegistries.MACHINE_MENU.get(), syncId, playerInventory, inventory);
         this.guiParams = guiParams;
 

--- a/src/main/java/aztech/modern_industrialization/machines/guicomponents/GunpowderOverclockGui.java
+++ b/src/main/java/aztech/modern_industrialization/machines/guicomponents/GunpowderOverclockGui.java
@@ -24,56 +24,45 @@
 
 package aztech.modern_industrialization.machines.guicomponents;
 
-import aztech.modern_industrialization.machines.GuiComponents;
-import aztech.modern_industrialization.machines.gui.GuiComponent;
+import aztech.modern_industrialization.MI;
+import aztech.modern_industrialization.machines.gui.GuiComponentServer;
 import java.util.function.Supplier;
 import net.minecraft.network.RegistryFriendlyByteBuf;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
 
-public class GunpowderOverclockGui {
-    public static class Server implements GuiComponent.Server<Integer> {
-        public final Parameters params;
-        public final Supplier<Integer> remTickSupplier;
+public class GunpowderOverclockGui implements GuiComponentServer<GunpowderOverclockGui.Params, Integer> {
+    public static final Type<Params, Integer> TYPE = new Type<>(MI.id("gunpowder_overclock_gui"), Params.STREAM_CODEC, ByteBufCodecs.VAR_INT);
 
-        public Server(Parameters params, Supplier<Integer> remTickSupplier) {
-            this.params = params;
-            this.remTickSupplier = remTickSupplier;
-        }
+    public final Params params;
+    public final Supplier<Integer> remTickSupplier;
 
-        @Override
-        public Integer copyData() {
-            return remTickSupplier.get();
-        }
-
-        @Override
-        public boolean needsSync(Integer cachedData) {
-            return !cachedData.equals(remTickSupplier.get());
-        }
-
-        @Override
-        public void writeInitialData(RegistryFriendlyByteBuf buf) {
-            buf.writeInt(params.renderX);
-            buf.writeInt(params.renderY);
-            writeCurrentData(buf);
-        }
-
-        @Override
-        public void writeCurrentData(RegistryFriendlyByteBuf buf) {
-            buf.writeInt(remTickSupplier.get());
-        }
-
-        @Override
-        public ResourceLocation getId() {
-            return GuiComponents.GUNPOWDER_OVERCLOCK_GUI;
-        }
+    public GunpowderOverclockGui(Params params, Supplier<Integer> remTickSupplier) {
+        this.params = params;
+        this.remTickSupplier = remTickSupplier;
     }
 
-    public static class Parameters {
-        public final int renderX, renderY;
+    @Override
+    public Params getParams() {
+        return params;
+    }
 
-        public Parameters(int renderX, int renderY) {
-            this.renderX = renderX;
-            this.renderY = renderY;
-        }
+    @Override
+    public Integer extractData() {
+        return remTickSupplier.get();
+    }
+
+    @Override
+    public Type<Params, Integer> getType() {
+        return TYPE;
+    }
+
+    public record Params(int renderX, int renderY) {
+        public static final StreamCodec<RegistryFriendlyByteBuf, Params> STREAM_CODEC = StreamCodec.composite(
+                ByteBufCodecs.VAR_INT,
+                Params::renderX,
+                ByteBufCodecs.VAR_INT,
+                Params::renderY,
+                Params::new);
     }
 }

--- a/src/main/java/aztech/modern_industrialization/machines/guicomponents/ReiSlotLocking.java
+++ b/src/main/java/aztech/modern_industrialization/machines/guicomponents/ReiSlotLocking.java
@@ -24,51 +24,43 @@
 
 package aztech.modern_industrialization.machines.guicomponents;
 
-import aztech.modern_industrialization.machines.GuiComponents;
-import aztech.modern_industrialization.machines.gui.GuiComponent;
+import aztech.modern_industrialization.MI;
+import aztech.modern_industrialization.machines.gui.GuiComponentServer;
 import java.util.function.Supplier;
-import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Unit;
 import net.minecraft.world.entity.player.Inventory;
 
-public class ReiSlotLocking {
+public class ReiSlotLocking implements GuiComponentServer<Unit, Boolean> {
+    public static final Type<Unit, Boolean> TYPE = new Type<>(MI.id("rei_slot_locking"), StreamCodec.unit(Unit.INSTANCE), ByteBufCodecs.BOOL);
+
+    public final SlotLockable slotLockable;
+    public final Supplier<Boolean> allowLocking;
+
+    public ReiSlotLocking(SlotLockable slotLockable, Supplier<Boolean> allowLocking) {
+        this.slotLockable = slotLockable;
+        this.allowLocking = allowLocking;
+    }
+
+    @Override
+    public Unit getParams() {
+        return Unit.INSTANCE;
+    }
+
+    @Override
+    public Boolean extractData() {
+        return allowLocking.get();
+    }
+
+    @Override
+    public Type<Unit, Boolean> getType() {
+        return TYPE;
+    }
+
     @FunctionalInterface
     public interface SlotLockable {
         void lockSlots(ResourceLocation recipeId, Inventory inventory);
-    }
-
-    public static class Server implements GuiComponent.Server<Boolean> {
-        public final SlotLockable slotLockable;
-        public final Supplier<Boolean> allowLocking;
-
-        public Server(SlotLockable slotLockable, Supplier<Boolean> allowLocking) {
-            this.slotLockable = slotLockable;
-            this.allowLocking = allowLocking;
-        }
-
-        @Override
-        public Boolean copyData() {
-            return allowLocking.get();
-        }
-
-        @Override
-        public boolean needsSync(Boolean cachedData) {
-            return allowLocking.get() != cachedData;
-        }
-
-        @Override
-        public void writeInitialData(RegistryFriendlyByteBuf buf) {
-            writeCurrentData(buf);
-        }
-
-        @Override
-        public void writeCurrentData(RegistryFriendlyByteBuf buf) {
-            buf.writeBoolean(allowLocking.get());
-        }
-
-        @Override
-        public ResourceLocation getId() {
-            return GuiComponents.REI_SLOT_LOCKING;
-        }
     }
 }

--- a/src/main/java/aztech/modern_industrialization/machines/init/MultiblockMachines.java
+++ b/src/main/java/aztech/modern_industrialization/machines/init/MultiblockMachines.java
@@ -594,7 +594,7 @@ public class MultiblockMachines {
 
     private static void clientInit() {
         MachineRegistrationHelper.addMachineModel("coke_oven", "coke_oven", MachineCasings.BRICKS, true, false, false);
-        new Rei("Coke Oven", "coke_oven", MIMachineRecipeTypes.COKE_OVEN, new ProgressBar.Parameters(77, 33, "arrow"))
+        new Rei("Coke Oven", "coke_oven", MIMachineRecipeTypes.COKE_OVEN, new ProgressBar.Params(77, 33, "arrow"))
                 .items(inputs -> inputs.addSlot(56, 35), outputs -> outputs.addSlot(102, 35))
                 .fluids(inputs -> {
                 }, outputs -> outputs.addSlot(102, 53))
@@ -602,7 +602,7 @@ public class MultiblockMachines {
                 .register();
 
         MachineRegistrationHelper.addMachineModel("steam_blast_furnace", "steam_blast_furnace", MachineCasings.FIREBRICKS, true, false, false);
-        new Rei("Steam Blast Furnace", "steam_blast_furnace", MIMachineRecipeTypes.BLAST_FURNACE, new ProgressBar.Parameters(77, 33, "arrow"))
+        new Rei("Steam Blast Furnace", "steam_blast_furnace", MIMachineRecipeTypes.BLAST_FURNACE, new ProgressBar.Params(77, 33, "arrow"))
                 .items(inputs -> inputs.addSlots(56, 35, 1, 2), outputs -> outputs.addSlots(102, 35, 1, 1))
                 .fluids(fluids -> fluids.addSlots(36, 35, 1, 1), outputs -> outputs.addSlots(122, 35, 1, 1))
                 .workstations("steam_blast_furnace", "electric_blast_furnace").extraTest(recipe -> recipe.eu <= 4)
@@ -622,12 +622,12 @@ public class MultiblockMachines {
                 false);
 
         MachineRegistrationHelper.addMachineModel("steam_quarry", "steam_quarry", MachineCasings.STEEL, true, false, false);
-        new Rei("Steam Quarry", "steam_quarry", MIMachineRecipeTypes.QUARRY, new ProgressBar.Parameters(77, 33, "arrow"))
+        new Rei("Steam Quarry", "steam_quarry", MIMachineRecipeTypes.QUARRY, new ProgressBar.Params(77, 33, "arrow"))
                 .items(inputs -> inputs.addSlot(56, 35), outputs -> outputs.addSlots(102, 35, 4, 4))
                 .workstations("steam_quarry", "electric_quarry").extraTest(recipe -> recipe.eu <= 4)
                 .steam(false)
                 .register();
-        new Rei("Electric Quarry", "electric_quarry", MIMachineRecipeTypes.QUARRY, new ProgressBar.Parameters(77, 33, "arrow"))
+        new Rei("Electric Quarry", "electric_quarry", MIMachineRecipeTypes.QUARRY, new ProgressBar.Params(77, 33, "arrow"))
                 .items(inputs -> inputs.addSlot(56, 35), outputs -> outputs.addSlots(102, 35, 4, 4))
                 .workstations("electric_quarry").extraTest(recipe -> recipe.eu > 4)
                 .register();
@@ -635,13 +635,13 @@ public class MultiblockMachines {
         MachineRegistrationHelper.addMachineModel("electric_quarry", "electric_quarry", MachineCasings.STEEL, true, false, false);
 
         MachineRegistrationHelper.addMachineModel("vacuum_freezer", "vacuum_freezer", MachineCasings.FROSTPROOF, true, false, false);
-        new Rei("Vacuum Freezer", "vacuum_freezer", MIMachineRecipeTypes.VACUUM_FREEZER, new ProgressBar.Parameters(77, 33, "arrow"))
+        new Rei("Vacuum Freezer", "vacuum_freezer", MIMachineRecipeTypes.VACUUM_FREEZER, new ProgressBar.Params(77, 33, "arrow"))
                 .items(inputs -> inputs.addSlots(56, 35, 1, 2), outputs -> outputs.addSlot(102, 35))
                 .fluids(inputs -> inputs.addSlots(36, 35, 1, 2), outputs -> outputs.addSlot(122, 35))
                 .register();
 
         MachineRegistrationHelper.addMachineModel("oil_drilling_rig", "oil_drilling_rig", MachineCasings.STEEL, true, false, false);
-        new Rei("Oil Drilling Rig", "oil_drilling_rig", MIMachineRecipeTypes.OIL_DRILLING_RIG, new ProgressBar.Parameters(77, 33, "arrow"))
+        new Rei("Oil Drilling Rig", "oil_drilling_rig", MIMachineRecipeTypes.OIL_DRILLING_RIG, new ProgressBar.Params(77, 33, "arrow"))
                 .items(inputs -> inputs.addSlot(36, 35), outputs -> {
                 })
                 .fluids(inputs -> {
@@ -649,7 +649,7 @@ public class MultiblockMachines {
                 .register();
 
         MachineRegistrationHelper.addMachineModel("distillation_tower", "distillation_tower", CLEAN_STAINLESS_STEEL, true, false, false);
-        new Rei("Distillation Tower", "distillation_tower", MIMachineRecipeTypes.DISTILLATION_TOWER, new ProgressBar.Parameters(77, 33, "arrow"))
+        new Rei("Distillation Tower", "distillation_tower", MIMachineRecipeTypes.DISTILLATION_TOWER, new ProgressBar.Params(77, 33, "arrow"))
                 .fluids(inputs -> inputs.addSlot(56, 35), outputs -> outputs.addSlots(102, 35, 8, 1))
                 .register();
 
@@ -658,13 +658,13 @@ public class MultiblockMachines {
         MachineRegistrationHelper.addMachineModel("large_steam_turbine", "steam_turbine", CLEAN_STAINLESS_STEEL, true, false, false);
 
         MachineRegistrationHelper.addMachineModel("heat_exchanger", "heat_exchanger", MachineCasings.STAINLESS_STEEL_PIPE, true, false, false);
-        new Rei("Heat Exchanger", "heat_exchanger", MIMachineRecipeTypes.HEAT_EXCHANGER, new ProgressBar.Parameters(77, 42, "arrow"))
+        new Rei("Heat Exchanger", "heat_exchanger", MIMachineRecipeTypes.HEAT_EXCHANGER, new ProgressBar.Params(77, 42, "arrow"))
                 .items(inputs -> inputs.addSlot(36, 35), outputs -> outputs.addSlot(122, 35))
                 .fluids(inputs -> inputs.addSlots(56, 35, 1, 2), outputs -> outputs.addSlots(102, 35, 1, 2))
                 .register();
 
         MachineRegistrationHelper.addMachineModel("pressurizer", "pressurizer", MachineCasings.TITANIUM_PIPE, true, false, false);
-        new Rei("Pressurizer", "pressurizer", MIMachineRecipeTypes.PRESSURIZER, new ProgressBar.Parameters(77, 33, "arrow"))
+        new Rei("Pressurizer", "pressurizer", MIMachineRecipeTypes.PRESSURIZER, new ProgressBar.Params(77, 33, "arrow"))
                 .items(inputs -> inputs.addSlot(38, 35), outputs -> {
                 })
                 .fluids(inputs -> inputs.addSlot(56, 35), outputs -> outputs.addSlot(102, 35))
@@ -672,7 +672,7 @@ public class MultiblockMachines {
 
         MachineRegistrationHelper.addMachineModel("implosion_compressor", "compressor", MachineCasings.SOLID_TITANIUM, true, false, false);
         new Rei("Implosion Compressor", "implosion_compressor", MIMachineRecipeTypes.IMPLOSION_COMPRESSOR,
-                new ProgressBar.Parameters(77, 42, "compress"))
+                new ProgressBar.Params(77, 42, "compress"))
                         .items(inputs -> inputs.addSlots(36, 35, 2, 2), outputs -> outputs.addSlot(102, 42))
                         .register();
 
@@ -683,7 +683,7 @@ public class MultiblockMachines {
 
         MachineRegistrationHelper.addMachineModel("fusion_reactor",
                 "fusion_reactor", CableTier.EV.casing, true, false, false, true);
-        new Rei("Fusion Reactor", "fusion_reactor", MIMachineRecipeTypes.FUSION_REACTOR, new ProgressBar.Parameters(66, 33, "arrow"))
+        new Rei("Fusion Reactor", "fusion_reactor", MIMachineRecipeTypes.FUSION_REACTOR, new ProgressBar.Params(66, 33, "arrow"))
                 .fluids(inputs -> inputs.addSlots(26, 35, 2, 1), outputs -> outputs.addSlots(92, 35, 3, 1))
                 .register();
 
@@ -706,7 +706,7 @@ public class MultiblockMachines {
 
             new Rei("EBF (%s Tier)".formatted(tier.englishName()), "electric_blast_furnace_" + tier.coilBlockId().getPath(),
                     MIMachineRecipeTypes.BLAST_FURNACE,
-                    new ProgressBar.Parameters(77, 33, "arrow"))
+                    new ProgressBar.Params(77, 33, "arrow"))
                             .items(inputs -> inputs.addSlots(56, 35, 1, 2), outputs -> outputs.addSlot(102, 35))
                             .fluids(fluids -> fluids.addSlot(36, 35), outputs -> outputs.addSlot(122, 35))
                             .extraTest(recipe -> previousMax < recipe.eu && recipe.eu <= currentMax)
@@ -720,7 +720,7 @@ public class MultiblockMachines {
         private final String englishName;
         private final ResourceLocation category;
         private final MachineRecipeType recipeType;
-        private final ProgressBar.Parameters progressBarParams;
+        private final ProgressBar.Params progressBarParams;
         private final List<ResourceLocation> workstations;
         // extra workstations to be displayed in viewers, can be any item id
         private final List<ResourceLocation> extraWorkstations;
@@ -731,7 +731,7 @@ public class MultiblockMachines {
         private final SlotPositions.Builder fluidOutputs = new SlotPositions.Builder();
         private SteamMode steamMode = SteamMode.ELECTRIC_ONLY;
 
-        public Rei(String englishName, ResourceLocation category, MachineRecipeType recipeType, ProgressBar.Parameters progressBarParams) {
+        public Rei(String englishName, ResourceLocation category, MachineRecipeType recipeType, ProgressBar.Params progressBarParams) {
             this.englishName = englishName;
             this.category = category;
             this.recipeType = recipeType;
@@ -741,7 +741,7 @@ public class MultiblockMachines {
             workstations.add(category);
         }
 
-        public Rei(String englishName, String category, MachineRecipeType recipeType, ProgressBar.Parameters progressBarParams) {
+        public Rei(String englishName, String category, MachineRecipeType recipeType, ProgressBar.Params progressBarParams) {
             this(englishName, MI.id(category), recipeType, progressBarParams);
         }
 

--- a/src/main/java/aztech/modern_industrialization/machines/init/SingleBlockCraftingMachines.java
+++ b/src/main/java/aztech/modern_industrialization/machines/init/SingleBlockCraftingMachines.java
@@ -55,91 +55,91 @@ public final class SingleBlockCraftingMachines {
         registerMachineTiers(
                 "Assembler", "assembler", MIMachineRecipeTypes.ASSEMBLER, 9, 3, 2, 0,
                 guiParams -> guiParams.backgroundHeight(186),
-                new ProgressBar.Parameters(105, 45, "circuit"), new RecipeEfficiencyBar.Parameters(48, 86), new EnergyBar.Parameters(14, 44),
+                new ProgressBar.Params(105, 45, "circuit"), new RecipeEfficiencyBar.Params(48, 86), new EnergyBar.Params(14, 44),
                 items -> items.addSlots(42, 27, 3, 3).addSlots(139, 27, 1, 3), fluids -> fluids.addSlots(98, 27, 2, 1),
                 true, true, false,
                 TIER_ELECTRIC, 16
         );
         registerMachineTiers(
                 "Centrifuge","centrifuge", MIMachineRecipeTypes.CENTRIFUGE, 1, 4, 1, 4, guiParams -> {},
-                new ProgressBar.Parameters(65, 33, "centrifuge"), new RecipeEfficiencyBar.Parameters(50, 66), DEFAULT_ENERGY_BAR,
+                new ProgressBar.Params(65, 33, "centrifuge"), new RecipeEfficiencyBar.Params(50, 66), DEFAULT_ENERGY_BAR,
                 items -> items.addSlot(42, 27).addSlots(93, 27, 2, 2), fluids -> fluids.addSlot(42, 45).addSlots(131, 27, 2, 2),
                 true, true, true,
                 TIER_ELECTRIC, 16
         );
         registerMachineTiers(
                 "Chemical Reactor", "chemical_reactor", MIMachineRecipeTypes.CHEMICAL_REACTOR, 3, 3, 3, 3, guiParams -> {},
-                new ProgressBar.Parameters(88, 35, "triple_arrow"), new RecipeEfficiencyBar.Parameters(50, 66), new EnergyBar.Parameters(12, 35),
+                new ProgressBar.Params(88, 35, "triple_arrow"), new RecipeEfficiencyBar.Params(50, 66), new EnergyBar.Params(12, 35),
                 items -> items.addSlots(30, 27, 3, 1).addSlots(116, 27, 3, 1), fluids -> fluids.addSlots(30, 47, 3, 1).addSlots(116, 47, 3, 1),
                 true, false, false,
                 TIER_ELECTRIC, 24
         );
         registerMachineTiers(
                 "Compressor", "compressor", MIMachineRecipeTypes.COMPRESSOR, 1, 1, 0, 0, guiParams -> {},
-                new ProgressBar.Parameters(77, 34, "compress"), new RecipeEfficiencyBar.Parameters(38, 62), new EnergyBar.Parameters(18, 30),
+                new ProgressBar.Params(77, 34, "compress"), new RecipeEfficiencyBar.Params(38, 62), new EnergyBar.Params(18, 30),
                 items -> items.addSlot(56, 35).addSlot(102, 35), fluids -> {},
                 true, true, true,
                 TIER_BRONZE | TIER_STEEL | TIER_ELECTRIC, 16
         );
         registerMachineTiers(
                 "Cutting Machine","cutting_machine", MIMachineRecipeTypes.CUTTING_MACHINE, 1, 1, 1, 0, guiParams -> {},
-                new ProgressBar.Parameters(88, 31, "slice"), new RecipeEfficiencyBar.Parameters(38, 62), new EnergyBar.Parameters(15, 34),
+                new ProgressBar.Params(88, 31, "slice"), new RecipeEfficiencyBar.Params(38, 62), new EnergyBar.Params(15, 34),
                 items -> items.addSlot(60, 35).addSlot(120, 35), fluids -> fluids.addSlot(40, 35),
                 true, false, false,
                 TIER_BRONZE | TIER_STEEL | TIER_ELECTRIC, 16
         );
         registerMachineTiers(
                 "Distillery", "distillery", MIMachineRecipeTypes.DISTILLERY, 0, 0, 1, 1, guiParams -> {},
-                new ProgressBar.Parameters(77, 33, "arrow"), new RecipeEfficiencyBar.Parameters(38, 62), new EnergyBar.Parameters(18, 30),
+                new ProgressBar.Params(77, 33, "arrow"), new RecipeEfficiencyBar.Params(38, 62), new EnergyBar.Params(18, 30),
                 items -> {}, fluids -> fluids.addSlot(56, 35).addSlot(102, 35),
                 true, false, false,
                 TIER_ELECTRIC, 16
         );
         registerMachineTiers(
                 "Electrolyzer", "electrolyzer", MIMachineRecipeTypes.ELECTROLYZER, 1, 4, 1, 4, guiParams -> {},
-                new ProgressBar.Parameters(66, 35, "arrow"), new RecipeEfficiencyBar.Parameters(50, 66), DEFAULT_ENERGY_BAR,
+                new ProgressBar.Params(66, 35, "arrow"), new RecipeEfficiencyBar.Params(50, 66), DEFAULT_ENERGY_BAR,
                 items -> items.addSlot(42, 27).addSlots(93, 27, 2, 2), fluids -> fluids.addSlot(42, 47).addSlots(131, 27, 2, 2),
                 true, false, true,
                 TIER_ELECTRIC, 16
         );
         registerMachineTiers(
                 "Furnace", "furnace", MIMachineRecipeTypes.FURNACE, 1, 1, 0, 0, guiParams -> {},
-                new ProgressBar.Parameters(77, 33, "arrow"), new RecipeEfficiencyBar.Parameters(38, 62), new EnergyBar.Parameters(18, 30),
+                new ProgressBar.Params(77, 33, "arrow"), new RecipeEfficiencyBar.Params(38, 62), new EnergyBar.Params(18, 30),
                 items -> items.addSlot(56, 35).addSlot(102, 35), fluids -> {},
                 true, false, false,
                 TIER_BRONZE | TIER_STEEL | TIER_ELECTRIC, 16
         );
         registerMachineTiers(
                 "Macerator", "macerator", MIMachineRecipeTypes.MACERATOR, 1, 4, 0, 0, guiParams -> {},
-                new ProgressBar.Parameters(77, 33, "macerate"), new RecipeEfficiencyBar.Parameters(38, 66), DEFAULT_ENERGY_BAR,
+                new ProgressBar.Params(77, 33, "macerate"), new RecipeEfficiencyBar.Params(38, 66), DEFAULT_ENERGY_BAR,
                 items -> items.addSlot(56, 35).addSlots(102, 27, 2, 2), fluids -> {},
                 true, true, false,
                 TIER_BRONZE | TIER_STEEL | TIER_ELECTRIC, 16
         );
         registerMachineTiers(
                 "Mixer", "mixer", MIMachineRecipeTypes.MIXER, 4, 2, 2, 2, guiParams -> {},
-                new ProgressBar.Parameters(103, 33, "arrow"), new RecipeEfficiencyBar.Parameters(50, 66), new EnergyBar.Parameters(15, 34),
+                new ProgressBar.Params(103, 33, "arrow"), new RecipeEfficiencyBar.Params(50, 66), new EnergyBar.Params(15, 34),
                 items -> items.addSlots(62, 27, 2, 2).addSlots(129, 27, 1, 2), fluids -> fluids.addSlots(42, 27, 1, 2).addSlots(149, 27, 1, 2),
                 true, true, true,
                 TIER_BRONZE | TIER_STEEL | TIER_ELECTRIC, 16
         );
         registerMachineTiers(
                 "Packer", "packer", MIMachineRecipeTypes.PACKER, 3, 1, 0, 0, guiParams -> guiParams.backgroundHeight(178),
-                new ProgressBar.Parameters(77, 33, "arrow"), new RecipeEfficiencyBar.Parameters(38, 74), new EnergyBar.Parameters(18, 30),
+                new ProgressBar.Params(77, 33, "arrow"), new RecipeEfficiencyBar.Params(38, 74), new EnergyBar.Params(18, 30),
                 items -> items.addSlots(56, 18, 1, 3).addSlot(102, 36), fluids -> {},
                 true, false, false,
                 TIER_STEEL | TIER_ELECTRIC, 16
         );
         registerMachineTiers(
                 "Polarizer", "polarizer", MIMachineRecipeTypes.POLARIZER, 2, 1, 0, 0, guiParams -> {},
-                new ProgressBar.Parameters(77, 30, "magnet"), new RecipeEfficiencyBar.Parameters(38, 62), new EnergyBar.Parameters(18, 30),
+                new ProgressBar.Params(77, 30, "magnet"), new RecipeEfficiencyBar.Params(38, 62), new EnergyBar.Params(18, 30),
                 items -> items.addSlots(56, 23, 1, 2).addSlot(102, 32), fluids -> {},
                 true, true, false,
                 TIER_ELECTRIC, 16
         );
         registerMachineTiers(
                 "Wiremill", "wiremill", MIMachineRecipeTypes.WIREMILL, 1, 1, 0, 0, guiParams -> {},
-                new ProgressBar.Parameters(77, 34, "wiremill"), new RecipeEfficiencyBar.Parameters(38, 62), new EnergyBar.Parameters(18, 30),
+                new ProgressBar.Params(77, 34, "wiremill"), new RecipeEfficiencyBar.Params(38, 62), new EnergyBar.Params(18, 30),
                 items -> items.addSlot(56, 35).addSlot(102, 35), fluids -> {},
                 true, true, false,
                 TIER_STEEL | TIER_ELECTRIC, 16
@@ -147,7 +147,7 @@ public final class SingleBlockCraftingMachines {
 
         registerMachineTiers(
                 "Unpacker", "unpacker", MIMachineRecipeTypes.UNPACKER, 1, 2, 0, 0, guiParams -> {},
-                new ProgressBar.Parameters(77, 33, "arrow"), new RecipeEfficiencyBar.Parameters(38, 66), new EnergyBar.Parameters(18, 30),
+                new ProgressBar.Params(77, 33, "arrow"), new RecipeEfficiencyBar.Params(38, 66), new EnergyBar.Params(18, 30),
                 items -> items.addSlots(56, 36, 1, 1).addSlots(102, 27, 1, 2), fluids -> {},
                 true, false, false,
                 TIER_STEEL | TIER_ELECTRIC, 16
@@ -155,12 +155,12 @@ public final class SingleBlockCraftingMachines {
         // @formatter:on
     }
 
-    private static final EnergyBar.Parameters DEFAULT_ENERGY_BAR = new EnergyBar.Parameters(18, 34);
+    private static final EnergyBar.Params DEFAULT_ENERGY_BAR = new EnergyBar.Params(18, 34);
 
     public static void registerMachineTiers(String englishName, String machine, MachineRecipeType type, int itemInputCount, int itemOutputCount,
             int fluidInputCount,
-            int fluidOutputCount, Consumer<MachineGuiParameters.Builder> guiParams, ProgressBar.Parameters progressBarParams,
-            RecipeEfficiencyBar.Parameters efficiencyBarParams, EnergyBar.Parameters energyBarParams, Consumer<SlotPositions.Builder> itemPositions,
+            int fluidOutputCount, Consumer<MachineGuiParameters.Builder> guiParams, ProgressBar.Params progressBarParams,
+            RecipeEfficiencyBar.Params efficiencyBarParams, EnergyBar.Params energyBarParams, Consumer<SlotPositions.Builder> itemPositions,
             Consumer<SlotPositions.Builder> fluidPositions, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, int tiers,
             int ioBucketCapacity) {
         registerMachineTiers(englishName, machine, type, itemInputCount, itemOutputCount, fluidInputCount, fluidOutputCount,
@@ -170,8 +170,8 @@ public final class SingleBlockCraftingMachines {
 
     public static void registerMachineTiers(String englishName, String machine, MachineRecipeType type, int itemInputCount, int itemOutputCount,
             int fluidInputCount,
-            int fluidOutputCount, Consumer<MachineGuiParameters.Builder> guiParams, ProgressBar.Parameters progressBarParams,
-            RecipeEfficiencyBar.Parameters efficiencyBarParams, EnergyBar.Parameters energyBarParams, Consumer<SlotPositions.Builder> itemPositions,
+            int fluidOutputCount, Consumer<MachineGuiParameters.Builder> guiParams, ProgressBar.Params progressBarParams,
+            RecipeEfficiencyBar.Params efficiencyBarParams, EnergyBar.Params energyBarParams, Consumer<SlotPositions.Builder> itemPositions,
             Consumer<SlotPositions.Builder> fluidPositions, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, int tiers,
             int ioBucketCapacity, Config extraConfig) {
         for (int i = 0; i < 2; ++i) {

--- a/src/main/java/aztech/modern_industrialization/network/machines/ChangeShapePacket.java
+++ b/src/main/java/aztech/modern_industrialization/network/machines/ChangeShapePacket.java
@@ -24,7 +24,6 @@
 
 package aztech.modern_industrialization.network.machines;
 
-import aztech.modern_industrialization.machines.GuiComponents;
 import aztech.modern_industrialization.machines.gui.MachineMenuServer;
 import aztech.modern_industrialization.machines.guicomponents.ShapeSelection;
 import aztech.modern_industrialization.network.BasePacket;
@@ -50,7 +49,7 @@ public record ChangeShapePacket(int syncId, int shapeLine, boolean clickedLeftBu
 
         AbstractContainerMenu menu = ctx.getPlayer().containerMenu;
         if (menu.containerId == syncId && menu instanceof MachineMenuServer machineMenu) {
-            ShapeSelection.Server shapeSelection = machineMenu.blockEntity.guiComponents.get(GuiComponents.SHAPE_SELECTION);
+            var shapeSelection = machineMenu.blockEntity.guiComponents.getOrThrow(ShapeSelection.class);
             shapeSelection.behavior.handleClick(shapeLine, clickedLeftButton ? -1 : +1);
         }
     }

--- a/src/main/java/aztech/modern_industrialization/network/machines/ReiLockSlotsPacket.java
+++ b/src/main/java/aztech/modern_industrialization/network/machines/ReiLockSlotsPacket.java
@@ -24,7 +24,6 @@
 
 package aztech.modern_industrialization.network.machines;
 
-import aztech.modern_industrialization.machines.GuiComponents;
 import aztech.modern_industrialization.machines.gui.MachineMenuServer;
 import aztech.modern_industrialization.machines.guicomponents.ReiSlotLocking;
 import aztech.modern_industrialization.network.BasePacket;
@@ -49,7 +48,7 @@ public record ReiLockSlotsPacket(int containedId, ResourceLocation recipeId) imp
         AbstractContainerMenu sh = ctx.getPlayer().containerMenu;
         if (sh.containerId == containedId && sh instanceof MachineMenuServer screenHandler) {
             // Check that locking the slots is allowed in the first place
-            ReiSlotLocking.Server slotLocking = screenHandler.blockEntity.guiComponents.get(GuiComponents.REI_SLOT_LOCKING);
+            var slotLocking = screenHandler.blockEntity.guiComponents.getOrThrow(ReiSlotLocking.class);
             if (!slotLocking.allowLocking.get())
                 return;
 

--- a/src/main/java/aztech/modern_industrialization/network/machines/SetAutoExtractPacket.java
+++ b/src/main/java/aztech/modern_industrialization/network/machines/SetAutoExtractPacket.java
@@ -24,7 +24,6 @@
 
 package aztech.modern_industrialization.network.machines;
 
-import aztech.modern_industrialization.machines.GuiComponents;
 import aztech.modern_industrialization.machines.components.OrientationComponent;
 import aztech.modern_industrialization.machines.gui.MachineMenuServer;
 import aztech.modern_industrialization.machines.guicomponents.AutoExtract;
@@ -50,7 +49,7 @@ public record SetAutoExtractPacket(int syncId, boolean isItem, boolean isExtract
 
         if (ctx.getPlayer().containerMenu.containerId == syncId) {
             var screenHandler = (MachineMenuServer) ctx.getPlayer().containerMenu;
-            AutoExtract.Server autoExtract = screenHandler.blockEntity.guiComponents.get(GuiComponents.AUTO_EXTRACT);
+            var autoExtract = screenHandler.blockEntity.guiComponents.getOrThrow(AutoExtract.class);
             OrientationComponent orientation = autoExtract.getOrientation();
             if (isItem) {
                 orientation.extractItems = isExtract;


### PR DESCRIPTION
Every `GuiComponentServer` now has two generic parameters: `P` or "params" for data that is only sent when the GUI is opened, and `D` or "synced data" for data that is sent both when the GUI is opened and every time it changes. The data will be `equals()`-compared every tick, and sent if necessary. Both params and data are written using stream codecs.