### PR TITLE
Allow for no machine rotation, use it for energy input hatches

### DIFF
--- a/src/client/java/aztech/modern_industrialization/client/machines/MachineBlockEntityRenderer.java
+++ b/src/client/java/aztech/modern_industrialization/client/machines/MachineBlockEntityRenderer.java
@@ -89,6 +89,9 @@ public class MachineBlockEntityRenderer<T extends MachineBlockEntity> implements
     @Nullable
     private BakedQuad getCachedQuad(MachineModelClientData data, Direction d) {
         var facing = data.frontDirection;
+        if (data.frontDirection == null) {
+            return null;
+        }
         int cachedQuadIndex = facing.ordinal() * 6 + d.ordinal();
         var casing = data.casing;
         var cachedQuads = quadCache.computeIfAbsent(casing, c -> new Object[36]);

--- a/src/client/java/aztech/modern_industrialization/client/machines/MachineOverlayClient.java
+++ b/src/client/java/aztech/modern_industrialization/client/machines/MachineOverlayClient.java
@@ -28,7 +28,7 @@ import aztech.modern_industrialization.MITags;
 import aztech.modern_industrialization.client.MIRenderTypes;
 import aztech.modern_industrialization.client.thirdparty.fabricrendering.QuadBuffer;
 import aztech.modern_industrialization.client.util.RenderHelper;
-import aztech.modern_industrialization.machines.MachineBlock;
+import aztech.modern_industrialization.machines.MachineBlockEntity;
 import aztech.modern_industrialization.machines.MachineOverlay;
 import aztech.modern_industrialization.util.GeometryHelper;
 import com.mojang.blaze3d.vertex.VertexConsumer;
@@ -36,7 +36,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.client.event.RenderHighlightEvent;
 import org.joml.Matrix4f;
@@ -47,8 +46,9 @@ public class MachineOverlayClient {
         var blockHitResult = event.getTarget();
 
         BlockPos pos = blockHitResult.getBlockPos();
-        BlockState state = Minecraft.getInstance().level.getBlockState(pos);
-        if (state.getBlock() instanceof MachineBlock
+        var level = Minecraft.getInstance().level;
+        if (level.getBlockEntity(pos) instanceof MachineBlockEntity machine
+                && machine.orientation != null
                 && Minecraft.getInstance().player.getMainHandItem().is(MITags.WRENCHES)) {
             var poseStack = event.getPoseStack();
 

--- a/src/client/java/aztech/modern_industrialization/client/machines/models/MachineBakedModel.java
+++ b/src/client/java/aztech/modern_industrialization/client/machines/models/MachineBakedModel.java
@@ -66,13 +66,13 @@ public class MachineBakedModel implements IDynamicBakedModel {
     }
 
     private final MachineCasing baseCasing;
-    private final TextureAtlasSprite[] defaultOverlays;
-    private final Map<MachineCasing, TextureAtlasSprite[]> tieredOverlays;
+    private final @Nullable TextureAtlasSprite[] defaultOverlays;
+    private final Map<MachineCasing, @Nullable TextureAtlasSprite[]> tieredOverlays;
     private final MachineModelClientData defaultData;
 
     MachineBakedModel(MachineCasing baseCasing,
-            TextureAtlasSprite[] defaultOverlays,
-            Map<MachineCasing, TextureAtlasSprite[]> tieredOverlays) {
+            @Nullable TextureAtlasSprite[] defaultOverlays,
+            Map<MachineCasing, @Nullable TextureAtlasSprite[]> tieredOverlays) {
         this.baseCasing = baseCasing;
         this.defaultOverlays = defaultOverlays;
         this.tieredOverlays = tieredOverlays;
@@ -83,7 +83,7 @@ public class MachineBakedModel implements IDynamicBakedModel {
         return baseCasing;
     }
 
-    public TextureAtlasSprite[] getSprites(@Nullable MachineCasing casing) {
+    public @Nullable TextureAtlasSprite[] getSprites(@Nullable MachineCasing casing) {
         if (casing == null) {
             return defaultOverlays;
         }
@@ -94,7 +94,7 @@ public class MachineBakedModel implements IDynamicBakedModel {
      * Returns null if nothing should be rendered.
      */
     @Nullable
-    public static TextureAtlasSprite getSprite(TextureAtlasSprite[] sprites, Direction side, Direction facingDirection, boolean isActive) {
+    public static TextureAtlasSprite getSprite(@Nullable TextureAtlasSprite[] sprites, Direction side, Direction facingDirection, boolean isActive) {
         int spriteId;
         if (side.getAxis().isHorizontal()) {
             spriteId = (facingDirection.get2DDataValue() - side.get2DDataValue() + 4) % 4 * 2;
@@ -139,7 +139,9 @@ public class MachineBakedModel implements IDynamicBakedModel {
             // Casing
             quads.addAll(getCasingModel(casing).getQuads(state, side, rand, extraData, renderType));
             // Machine overlays
-            TextureAtlasSprite sprite = getSprite(sprites, side, data.frontDirection, false);
+            // Draw the "front" texture on the north side if the machine has no facing
+            var facingDirection = Objects.requireNonNullElse(data.frontDirection, Direction.NORTH);
+            TextureAtlasSprite sprite = getSprite(sprites, side, facingDirection, false);
             if (sprite != null) {
                 quads.add(ModelHelper.bakeSprite(vc, side, sprite, -Z_OFFSET));
             }

--- a/src/client/java/aztech/modern_industrialization/client/machines/models/MachineUnbakedModel.java
+++ b/src/client/java/aztech/modern_industrialization/client/machines/models/MachineUnbakedModel.java
@@ -76,14 +76,14 @@ public class MachineUnbakedModel implements IUnbakedGeometry<MachineUnbakedModel
     public BakedModel bake(IGeometryBakingContext context, ModelBaker baker, Function<Material, TextureAtlasSprite> spriteGetter,
             ModelState modelState, ItemOverrides overrides) {
         var defaultOverlays = loadSprites(spriteGetter, this.defaultOverlays);
-        var tieredOverlays = new HashMap<MachineCasing, TextureAtlasSprite[]>();
+        var tieredOverlays = new HashMap<MachineCasing, @Nullable TextureAtlasSprite[]>();
         for (var entry : this.tieredOverlays.entrySet()) {
             tieredOverlays.put(entry.getKey(), loadSprites(spriteGetter, entry.getValue()));
         }
         return new MachineBakedModel(baseCasing, defaultOverlays, tieredOverlays);
     }
 
-    private static TextureAtlasSprite[] loadSprites(Function<Material, TextureAtlasSprite> textureGetter, @Nullable Material[] ids) {
+    private static @Nullable TextureAtlasSprite[] loadSprites(Function<Material, TextureAtlasSprite> textureGetter, @Nullable Material[] ids) {
         var sprites = new TextureAtlasSprite[ids.length];
         for (int i = 0; i < ids.length; ++i) {
             if (ids[i] != null) {

--- a/src/main/java/aztech/modern_industrialization/machines/MachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/MachineBlockEntity.java
@@ -86,16 +86,21 @@ public abstract class MachineBlockEntity extends FastBlockEntity
     @Nullable
     private Boolean hasRedstoneHighSignal = null;
 
+    @Nullable
     public final OrientationComponent orientation;
     public final PlacedByComponent placedBy;
 
-    public MachineBlockEntity(BEP bep, MachineGuiParameters guiParams, OrientationComponent.Params orientationParams) {
+    public MachineBlockEntity(BEP bep, MachineGuiParameters guiParams, OrientationComponent.@Nullable Params orientationParams) {
         super(bep.type(), bep.pos(), bep.state());
         this.guiParams = guiParams;
-        this.orientation = new OrientationComponent(orientationParams, this);
+        if (orientationParams == null) {
+            this.orientation = null;
+        } else {
+            this.orientation = new OrientationComponent(orientationParams, this);
+            registerComponents(orientation);
+        }
         this.placedBy = new PlacedByComponent();
-
-        registerComponents(orientation, placedBy);
+        registerComponents(placedBy);
     }
 
     protected final void registerGuiComponent(GuiComponentServer... components) {
@@ -162,13 +167,15 @@ public abstract class MachineBlockEntity extends FastBlockEntity
 
     @MustBeInvokedByOverriders
     public void onPlaced(@Nullable LivingEntity placer, ItemStack itemStack) {
-        orientation.onPlaced(placer, itemStack);
+        if (orientation != null) {
+            orientation.onPlaced(placer, itemStack);
+        }
         placedBy.onPlaced(placer);
     }
 
     @Override
     public boolean useWrench(Player player, InteractionHand hand, BlockHitResult hitResult) {
-        if (orientation.useWrench(player, hand, MachineOverlay.findHitSide(hitResult))) {
+        if (orientation != null && orientation.useWrench(player, hand, MachineOverlay.findHitSide(hitResult))) {
             getLevel().blockUpdated(getBlockPos(), Blocks.AIR);
             setChanged();
             if (!getLevel().isClientSide()) {

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/EnergyHatch.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/hatches/EnergyHatch.java
@@ -45,7 +45,7 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 
 public class EnergyHatch extends HatchBlockEntity implements EnergyComponentHolder, CableTierHolder {
     public EnergyHatch(BEP bep, MachineGuiParameters guiParams, boolean input, CableTier tier) {
-        super(bep, guiParams, new OrientationComponent.Params(!input, false, false));
+        super(bep, guiParams, input ? null : new OrientationComponent.Params(true, false, false));
 
         this.input = input;
         this.tier = tier;

--- a/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/multiblocks/HatchBlockEntity.java
@@ -46,7 +46,7 @@ import net.minecraft.world.item.ItemStack;
 import org.jspecify.annotations.Nullable;
 
 public abstract class HatchBlockEntity extends MachineBlockEntity implements Tickable {
-    public HatchBlockEntity(BEP bep, MachineGuiParameters guiParams, OrientationComponent.Params orientationParams) {
+    public HatchBlockEntity(BEP bep, MachineGuiParameters guiParams, OrientationComponent.@Nullable Params orientationParams) {
         super(bep, guiParams, orientationParams);
 
         registerComponents(new MachineComponent.ClientOnly() {
@@ -109,14 +109,16 @@ public abstract class HatchBlockEntity extends MachineBlockEntity implements Tic
     public MachineModelClientData getMachineModelData() {
         MachineCasing casing = isMatched() ? MachineCasings.get(matchedCasing) : null;
         MachineModelClientData data = new MachineModelClientData(casing);
-        orientation.writeModelData(data);
+        if (orientation != null) {
+            orientation.writeModelData(data);
+        }
         return data;
     }
 
     @Override
     public void onPlaced(@Nullable LivingEntity placer, ItemStack itemStack) {
         super.onPlaced(placer, itemStack);
-        if (orientation.params.hasOutput) {
+        if (orientation != null && orientation.params.hasOutput) {
             orientation.outputDirection = orientation.outputDirection.getOpposite();
         }
     }

--- a/src/main/java/aztech/modern_industrialization/machines/recipe/condition/AdjacentBlockProcessCondition.java
+++ b/src/main/java/aztech/modern_industrialization/machines/recipe/condition/AdjacentBlockProcessCondition.java
@@ -59,14 +59,21 @@ public record AdjacentBlockProcessCondition(Block block, RelativePosition relati
 
     @Override
     public boolean canProcessRecipe(Context context, MachineRecipe recipe) {
-        var checkPos = switch (relativePosition) {
-            case BELOW -> context.getBlockEntity().getBlockPos().below();
+        return switch (relativePosition) {
+            case BELOW -> {
+                var checkPos = context.getBlockEntity().getBlockPos().below();
+                yield context.getLevel().getBlockState(checkPos).is(block);
+            }
             case BEHIND -> {
-                var direction = context.getBlockEntity().orientation.facingDirection;
-                yield context.getBlockEntity().getBlockPos().relative(direction.getOpposite());
+                var orientation = context.getBlockEntity().orientation;
+                if (orientation == null) {
+                    yield false;
+                }
+                var direction = orientation.facingDirection;
+                var checkPos = context.getBlockEntity().getBlockPos().relative(direction.getOpposite());
+                yield context.getLevel().getBlockState(checkPos).is(block);
             }
         };
-        return context.getLevel().getBlockState(checkPos).is(block);
     }
 
     @Override


### PR DESCRIPTION
Technical changes:
- The `OrientationComponent` of a machine can now be `null`.
- Machines with a `null` `OrientationComponent` don't get an overlay when targeted by a wrench, and in fact the wrench doesn't do anything on them.
- Machine model data with a `null` `frontDirection` is supported by the standard machine model and BER.

The energy input hatches are for now the only such machines in MI itself.