### PR TITLE
Split insertion and extraction value tracking in pipe stats

### DIFF
--- a/src/main/java/aztech/modern_industrialization/pipes/PipeStatsCollector.java
+++ b/src/main/java/aztech/modern_industrialization/pipes/PipeStatsCollector.java
@@ -28,16 +28,23 @@ public class PipeStatsCollector {
     private static final int REFRESH_RATE = 20;
 
     private long lastStat = 0;
-    private long currentTot = 0;
+    private long currentTotInsert = 0;
+    private long currentTotExtract = 0;
     private int ticks = 0;
 
     public void addValue(long newMoved) {
-        currentTot += newMoved;
+        addValues(newMoved, 0);
+    }
+
+    public void addValues(long extracted, long inserted) {
+        currentTotExtract += extracted;
+        currentTotInsert += inserted;
         ticks++;
 
         if (ticks == REFRESH_RATE) {
-            lastStat = currentTot / REFRESH_RATE;
-            currentTot = 0;
+            lastStat = Math.max(currentTotExtract, currentTotInsert) / REFRESH_RATE;
+            currentTotExtract = 0;
+            currentTotInsert = 0;
             ticks = 0;
         }
     }

--- a/src/main/java/aztech/modern_industrialization/pipes/electricity/ElectricityNetwork.java
+++ b/src/main/java/aztech/modern_industrialization/pipes/electricity/ElectricityNetwork.java
@@ -70,7 +70,7 @@ public class ElectricityNetwork extends PipeNetwork {
         long inserted = transferForTargets(MIEnergyStorage::receive, storages, insertMaxAmount);
         networkAmount -= inserted;
 
-        stats.addValue(Math.max(extracted, inserted));
+        stats.addValues(extracted, inserted);
 
         // Split energy evenly across the nodes
         for (var entry : iterateTickingNodes()) {

--- a/src/main/java/aztech/modern_industrialization/pipes/fluid/FluidNetwork.java
+++ b/src/main/java/aztech/modern_industrialization/pipes/fluid/FluidNetwork.java
@@ -113,7 +113,7 @@ public class FluidNetwork extends PipeNetwork {
             }
         }
 
-        stats.addValue(Math.max(extracted, inserted));
+        stats.addValues(extracted, inserted);
         capacityStats.addValue(networkCapacity);
 
         for (var entry : iterateTickingNodes()) {


### PR DESCRIPTION
This pull request fixes a niche bug in how the pipe statistics tracking works.

If an extraction and an insertion don't happen in the same tick, the effective flow rate is doubled because both operations are tracked as individual steps. My fix separates the tracking of the extraction and the insertion, and takes the higher value for the statistics value.

The bug can be reproduced by a machine that only uses energy every 2 ticks.
A more in-depth discussion about this issue can be found [on the Discord](https://discord.com/channels/754461970870173767/760125612126896196/1476543821117390974).