### PR TITLE
Only include caller class of transactions when config option is true (false by default)

### DIFF
--- a/src/main/java/aztech/modern_industrialization/config/MIStartupConfig.java
+++ b/src/main/java/aztech/modern_industrialization/config/MIStartupConfig.java
@@ -50,6 +50,7 @@ public final class MIStartupConfig {
     public final ModConfigSpec.BooleanValue datagenOnStartup;
     public final ModConfigSpec.BooleanValue loadRuntimeGeneratedResources;
 
+    public final ModConfigSpec.BooleanValue transactionCallerName;
     // These should ideally be moved to the server config one day.
     public final ModConfigSpec.BooleanValue debugCommands;
     public final ModConfigSpec.IntValue maxDistillationTowerHeight;
@@ -93,6 +94,11 @@ public final class MIStartupConfig {
                 .define("loadRuntimeGeneratedResources", false);
         builder.popSection();
 
+        this.transactionCallerName = builder.start("transactionCallerName",
+                "Include Transaction Caller Name",
+                "Enable to have transfer transactions include the name of the class that called it.",
+                "Note that this comes at the cost of performance. It is recommended to not use this outside of debugging.")
+                .define("transactionCallerName", !FMLEnvironment.production);
         this.debugCommands = builder.start("debugCommands",
                 "Debug commands",
                 "Enable UNSUPPORTED and DANGEROUS debug commands.")

--- a/src/main/java/aztech/modern_industrialization/thirdparty/fabrictransfer/api/transaction/Transaction.java
+++ b/src/main/java/aztech/modern_industrialization/thirdparty/fabrictransfer/api/transaction/Transaction.java
@@ -24,6 +24,7 @@
 
 package aztech.modern_industrialization.thirdparty.fabrictransfer.api.transaction;
 
+import aztech.modern_industrialization.config.MIStartupConfig;
 import java.util.ArrayList;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
@@ -98,7 +99,7 @@ public final class Transaction implements AutoCloseable, TransactionContext {
      */
     public static Transaction openRoot() {
         // Don't delegate to other method due to getCallerClass()
-        return TransactionManager.getManagerForThread().open(null, STACK_WALKER.getCallerClass());
+        return TransactionManager.getManagerForThread().open(null, MIStartupConfig.INSTANCE.transactionCallerName.getAsBoolean() ? STACK_WALKER.getCallerClass() : null);
     }
 
     /**
@@ -119,7 +120,7 @@ public final class Transaction implements AutoCloseable, TransactionContext {
      */
     public static Transaction open(@Nullable TransactionContext parent) {
         // Don't delegate to other method due to getCallerClass()
-        return TransactionManager.getManagerForThread().open(parent, STACK_WALKER.getCallerClass());
+        return TransactionManager.getManagerForThread().open(parent, MIStartupConfig.INSTANCE.transactionCallerName.getAsBoolean() ? STACK_WALKER.getCallerClass() : null);
     }
 
     public static Transaction hackyOpen() {
@@ -228,7 +229,7 @@ public final class Transaction implements AutoCloseable, TransactionContext {
      * Gets what should be printed during exceptions to represent the caller class. This should include the package name as well.
      */
     String getDebugName() {
-        return callerClass.toString();
+        return callerClass != null ? callerClass.toString() : "N/A";
     }
 
     /**

--- a/src/main/java/aztech/modern_industrialization/thirdparty/fabrictransfer/api/transaction/TransactionManager.java
+++ b/src/main/java/aztech/modern_industrialization/thirdparty/fabrictransfer/api/transaction/TransactionManager.java
@@ -60,7 +60,7 @@ final class TransactionManager {
         } else if (currentDepth >= 0) {
             String currentRoot = getOpenTransaction(0).getDebugName();
             throw new IllegalStateException("A root transaction of `" + currentRoot + "` is already active on this thread " + thread + " when `"
-                    + callerClass + "` tried to open.");
+                    + (callerClass == null ? "N/A" : callerClass) + "` tried to open.");
         }
 
         Transaction current;


### PR DESCRIPTION
Calling `StackWalker#getCallerClass` frequently comes with a cost of performance. This adds a config option that is off by default that must be on for the caller class to be fetched.