### PR TITLE
Fix #1268: Crash when attempting to access Pneumaticraft Logistic once placed on MI Machine Blocks

### DIFF
--- a/src/main/java/aztech/modern_industrialization/machines/MachineBlock.java
+++ b/src/main/java/aztech/modern_industrialization/machines/MachineBlock.java
@@ -84,9 +84,11 @@ public class MachineBlock extends Block implements TickableBlock {
 
     @Override
     protected InteractionResult useWithoutItem(BlockState state, Level level, BlockPos pos, Player player, BlockHitResult hit) {
-        BlockEntity be = level.getBlockEntity(pos);
-        if (be instanceof MachineBlockEntity machine) {
-            machine.openMenu((ServerPlayer) player);
+        if (!level.isClientSide) {
+            BlockEntity be = level.getBlockEntity(pos);
+            if (be instanceof MachineBlockEntity machine) {
+                machine.openMenu((ServerPlayer) player);
+            }
         }
         return InteractionResult.sidedSuccess(level.isClientSide);
     }


### PR DESCRIPTION
Fixes #1268 