### PR TITLE
Fix #1271: Quantum Sword stopped by Weakness effect

### DIFF
--- a/src/main/java/aztech/modern_industrialization/MI.java
+++ b/src/main/java/aztech/modern_industrialization/MI.java
@@ -72,9 +72,11 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.inventory.AnvilMenu;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
@@ -83,6 +85,7 @@ import net.neoforged.fml.config.ModConfig;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.fml.loading.FMLPaths;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
+import net.neoforged.neoforge.client.event.GatherSkippedAttributeTooltipsEvent;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
 import net.neoforged.neoforge.event.AddPackFindersEvent;
@@ -198,6 +201,18 @@ public class MI {
             if (event.getSource().getDirectEntity() instanceof LivingEntity damager
                     && damager.getAttributeValue(MIRegistries.INFINITE_DAMAGE) > Mth.EPSILON) {
                 event.setAmount((float) Integer.MAX_VALUE);
+            }
+        });
+        NeoForge.EVENT_BUS.addListener(GatherSkippedAttributeTooltipsEvent.class, event -> {
+            // Hides the attack damage attribute on items when the infinite damage attribute is present
+            boolean hasInfiniteDamageAttribute = event.getStack().getAttributeModifiers().modifiers().stream()
+                    .anyMatch((modifier) -> modifier.attribute().is(MIRegistries.INFINITE_DAMAGE.getKey()));
+            if (hasInfiniteDamageAttribute) {
+                for (ItemAttributeModifiers.Entry modifier : event.getStack().getAttributeModifiers().modifiers()) {
+                    if (modifier.attribute().is(Attributes.ATTACK_DAMAGE.getKey())) {
+                        event.skipId(modifier.modifier().id());
+                    }
+                }
             }
         });
 

--- a/src/main/java/aztech/modern_industrialization/items/tools/QuantumSword.java
+++ b/src/main/java/aztech/modern_industrialization/items/tools/QuantumSword.java
@@ -31,6 +31,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EquipmentSlotGroup;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -43,6 +44,16 @@ public class QuantumSword extends Item {
 
     public QuantumSword(Properties settings) {
         super(settings.attributes(ItemAttributeModifiers.builder()
+                /*
+                 * Minecraft checks the attack damage attribute value for an attack before the LivingDamageEvent is
+                 * handled, which is where the infinite damage attribute is applied. Because of this, if the attack
+                 * damage attribute is left default (1), when a weakness potion is applied to the attacking entity, the
+                 * damage value becomes 0 and thus the LivingDamageEvent is never called.
+                 */
+                .add(
+                        Attributes.ATTACK_DAMAGE,
+                        new AttributeModifier(BASE_ATTACK_DAMAGE_ID, 2048, AttributeModifier.Operation.ADD_VALUE),
+                        EquipmentSlotGroup.MAINHAND)
                 .add(
                         MIRegistries.INFINITE_DAMAGE,
                         new AttributeModifier(BASE_INFINITE_DAMAGE, 1, AttributeModifier.Operation.ADD_VALUE),

--- a/src/main/java/aztech/modern_industrialization/items/tools/QuantumSword.java
+++ b/src/main/java/aztech/modern_industrialization/items/tools/QuantumSword.java
@@ -46,9 +46,10 @@ public class QuantumSword extends Item {
         super(settings.attributes(ItemAttributeModifiers.builder()
                 /*
                  * Minecraft checks the attack damage attribute value for an attack before the LivingDamageEvent is
-                 * handled, which is where the infinite damage attribute is applied. Because of this, if the attack
-                 * damage attribute is left default (1), when a weakness potion is applied to the attacking entity, the
-                 * damage value becomes 0 and thus the LivingDamageEvent is never called.
+                 * handled, which is where the infinite damage attribute is applied. There is no event that can override
+                 * the value at that point. Because of this, if the attack damage attribute is left default (1), when a
+                 * weakness potion is applied to the attacking entity, the damage value becomes 0 and thus the damage is
+                 * ignored and LivingDamageEvent is never called.
                  */
                 .add(
                         Attributes.ATTACK_DAMAGE,


### PR DESCRIPTION
Fixes #1271 

This one's a bit weird so I think it warrants an explanation, which is included in a comment in the code for future reference.

Minecraft checks the attack damage attribute value for an attack before the LivingDamageEvent is handled, which is where the infinite damage attribute is applied. There is no event that can override the value at that point. Because of this, if the attack damage attribute is left default (1), when a weakness potion is applied to the attacking entity, the damage value becomes 0 and thus the damage is ignored and LivingDamageEvent is never called.

So, the fix here simply adds an attack damage attribute to the quantum sword. That way, the calculated damage value when weakness is present does not bring it below 0. The damage value here is 2048 because that is the maximum allowed by the attribute. The damage value is not applied, since it is overwritten in the existing `LivingIncomingDamageEvent` listener. The tooltip line added by that redundant attribute is skipped using the `GatherSkippedAttributeTooltipsEvent`.