### PR TITLE
Fix #1257: Shift clicking some recipes to slot lock the machine come up wrong sometimes

### DIFF
--- a/src/main/java/aztech/modern_industrialization/machines/components/CrafterComponent.java
+++ b/src/main/java/aztech/modern_industrialization/machines/components/CrafterComponent.java
@@ -727,15 +727,15 @@ public class CrafterComponent implements MachineComponent.ServerOnly, CrafterAcc
                                 return targetItem;
                             }
                         }
-                        // Find the first match that is an item from MI (useful for ingots for example)
+                        // Find the first match that is an item from MI or vanilla (useful for ingots for example)
                         for (Item item : inputItems) {
                             ResourceLocation id = BuiltInRegistries.ITEM.getKey(item);
-                            if (id.getNamespace().equals(MI.ID)) {
+                            if (id.getNamespace().equals(MI.ID) || id.getNamespace().equals("minecraft")) {
                                 return item;
                             }
                         }
-                        // If there is only one value in the tag, pick that one
-                        if (inputItems.size() == 1) {
+                        // If there are items in the tag, pick the first one
+                        if (!inputItems.isEmpty()) {
                             return inputItems.get(0);
                         }
                         return null;
@@ -765,15 +765,15 @@ public class CrafterComponent implements MachineComponent.ServerOnly, CrafterAcc
                             }
                         }
                         List<Fluid> inputFluids = input.getInputFluids();
-                        // Find the first match that is an item from MI
+                        // Find the first match that is an item from MI or vanilla
                         for (Fluid fluid : inputFluids) {
                             ResourceLocation id = BuiltInRegistries.FLUID.getKey(fluid);
-                            if (id.getNamespace().equals(MI.ID)) {
+                            if (id.getNamespace().equals(MI.ID) || id.getNamespace().equals("minecraft")) {
                                 return fluid;
                             }
                         }
-                        // If there is only one value in the tag, pick that one
-                        if (inputFluids.size() == 1) {
+                        // If there are fluids in the tag, pick the first one
+                        if (!inputFluids.isEmpty()) {
                             return inputFluids.get(0);
                         }
                         return null;


### PR DESCRIPTION
Fixes #1257 

So long as there are values in the tag, I believe it makes most sense if there are no better matches, at the very least use the first item in the tag. It is definitely confusing when _nothing_ gets locked to the slot when clicking the button. I do not see a better way to handle this. EMI does a similar thing, where if no model is provided for a tag, it simply displays the first item in the tag.