### PR TITLE
Fix #1113: Barrels cannot take or give stacks anymore

### DIFF
--- a/src/main/java/aztech/modern_industrialization/blocks/storage/barrel/BarrelBlock.java
+++ b/src/main/java/aztech/modern_industrialization/blocks/storage/barrel/BarrelBlock.java
@@ -30,6 +30,7 @@ import aztech.modern_industrialization.blocks.storage.StorageBehaviour;
 import aztech.modern_industrialization.thirdparty.fabrictransfer.api.item.ItemVariant;
 import aztech.modern_industrialization.thirdparty.fabrictransfer.api.transaction.Transaction;
 import aztech.modern_industrialization.util.MobSpawning;
+import aztech.modern_industrialization.util.TransferHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
@@ -43,6 +44,7 @@ import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.phys.BlockHitResult;
+import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
 
@@ -50,6 +52,21 @@ public class BarrelBlock extends AbstractStorageBlock<ItemVariant> implements En
     public BarrelBlock(EntityBlock factory, StorageBehaviour<ItemVariant> behaviour) {
         super(BlockBehaviour.Properties.of().mapColor(MapColor.METAL).destroyTime(4.0f).isValidSpawn(MobSpawning.NO_SPAWN)
                 .isRedstoneConductor(Blocks::never), factory, behaviour);
+    }
+
+    private static boolean transferWithItem(ItemStack stack, BarrelBlockEntity barrelBlockEntity, Direction direction, boolean fromItemToBarrel) {
+        if (stack.getItem() instanceof BarrelItem barrelItem) {
+            var itemItemHandler = Capabilities.ItemHandler.ITEM.getCapability(stack, null);
+            var blockItemHandler = Capabilities.ItemHandler.BLOCK.getCapability(
+                    barrelBlockEntity.getLevel(), barrelBlockEntity.getBlockPos(), barrelBlockEntity.getBlockState(),
+                    barrelBlockEntity, direction);
+            var source = fromItemToBarrel ? itemItemHandler : blockItemHandler;
+            var target = fromItemToBarrel ? blockItemHandler : itemItemHandler;
+            if (source != null && target != null) {
+                return TransferHelper.moveAll(source, target, true);
+            }
+        }
+        return false;
     }
 
     private static boolean useBlock(BlockHitResult hitResult, InteractionHand hand, Player player, Level world) {
@@ -65,15 +82,11 @@ public class BarrelBlock extends AbstractStorageBlock<ItemVariant> implements En
             }
 
             if (!player.isShiftKeyDown()) {
-                // TODO NEO implement item-item storage API support
-//                if (stack.getItem() instanceof BarrelItem barrelItem) {
-//                    var storage = ContainerItem.GenericItemStorage.of(stack, barrelItem);
-//                    if (StorageUtil.move(storage, barrelInserter, (itemVariant) -> true, Long.MAX_VALUE, null) > 0) {
-//                        return true;
-//                    }
-//                }
                 var handItem = player.getItemInHand(hand);
                 if (!handItem.isEmpty()) {
+                    if (transferWithItem(handItem, barrel, hitResult.getDirection(), true)) {
+                        return true;
+                    }
                     try (var tx = Transaction.openRoot()) {
                         long inserted = barrel.insert(ItemVariant.of(handItem), handItem.getCount(), tx, true);
                         if (inserted > 0) {
@@ -114,13 +127,9 @@ public class BarrelBlock extends AbstractStorageBlock<ItemVariant> implements En
             if (!barrel.isEmpty()) {
                 ItemStack stack = player.getItemInHand(hand);
 
-                // TODO NEO implement item-item storage API support
-//                if (stack.getItem() instanceof BarrelItem barrelItem) {
-//                    var storage = ContainerItem.GenericItemStorage.of(stack, barrelItem);
-//                    if (StorageUtil.move(barrel, storage, (itemVariant) -> true, Long.MAX_VALUE, null) > 0) {
-//                        return InteractionResult.sidedSuccess(world.isClientSide);
-//                    }
-//                }
+                if (transferWithItem(stack, barrel, direction, false)) {
+                    return true;
+                }
 
                 try (Transaction transaction = Transaction.openRoot()) {
                     ItemVariant extractedResource = barrel.getResource();

--- a/src/main/java/aztech/modern_industrialization/materials/part/BarrelPart.java
+++ b/src/main/java/aztech/modern_industrialization/materials/part/BarrelPart.java
@@ -37,6 +37,7 @@ import aztech.modern_industrialization.blocks.storage.barrel.BarrelBlockEntity;
 import aztech.modern_industrialization.blocks.storage.barrel.BarrelItem;
 import aztech.modern_industrialization.datagen.tag.TagsToGenerate;
 import aztech.modern_industrialization.definition.BlockDefinition;
+import aztech.modern_industrialization.items.ContainerItem;
 import aztech.modern_industrialization.items.SortOrder;
 import aztech.modern_industrialization.thirdparty.fabrictransfer.api.bridge.SlotItemHandler;
 import aztech.modern_industrialization.thirdparty.fabrictransfer.api.item.ItemVariant;
@@ -96,6 +97,9 @@ public class BarrelPart implements PartKeyProvider {
 
                     MICapabilities.onEvent(event -> {
                         event.registerBlockEntity(Capabilities.ItemHandler.BLOCK, bet.getValue(), (be, side) -> new SlotItemHandler(be));
+
+                        var item = (BarrelItem) blockDefinition.asItem();
+                        event.registerItem(Capabilities.ItemHandler.ITEM, (stack, ignored) -> new ContainerItem.ItemHandler(stack, item), item);
                     });
 
                     MICommonProxy.INSTANCE.registerPartBarrelClient(bet::getValue, partContext.get(MEAN_RGB));

--- a/src/main/java/aztech/modern_industrialization/util/TransferHelper.java
+++ b/src/main/java/aztech/modern_industrialization/util/TransferHelper.java
@@ -36,7 +36,8 @@ import net.neoforged.neoforge.items.ItemHandlerHelper;
 import net.neoforged.neoforge.items.wrapper.PlayerInvWrapper;
 
 public class TransferHelper {
-    public static void moveAll(IItemHandler src, IItemHandler target, boolean stackInTarget) {
+    public static boolean moveAll(IItemHandler src, IItemHandler target, boolean stackInTarget) {
+        boolean moved = false;
         int srcSlots = src.getSlots();
 
         for (int i = 0; i < srcSlots; ++i) {
@@ -59,6 +60,7 @@ public class TransferHelper {
             if (extracted.isEmpty()) {
                 continue;
             }
+            moved = true;
 
             leftover = stackInTarget ? ItemHandlerHelper.insertItemStacked(target, extracted, false)
                     : ItemHandlerHelper.insertItem(target, extracted, false);
@@ -71,6 +73,8 @@ public class TransferHelper {
                 }
             }
         }
+
+        return moved;
     }
 
     public static ItemStack extractMatching(Inventory inventory, Predicate<ItemStack> predicate, int maxAmount, boolean containers) {


### PR DESCRIPTION
Probably shouldn't close #1113 when this is merged, since it still needs to be done separately for 26.1