### PR TITLE
Support rotatable BlockStates and specific BlockEntities in multiblock shape matching

### DIFF
--- a/src/client/java/aztech/modern_industrialization/client/compat/viewer/usage/MultiblockCategory.java
+++ b/src/client/java/aztech/modern_industrialization/client/compat/viewer/usage/MultiblockCategory.java
@@ -33,17 +33,12 @@ import aztech.modern_industrialization.machines.multiblocks.ShapeTemplate;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.function.Consumer;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.RecipeManager;
-import net.minecraft.world.level.block.state.BlockState;
 import org.jspecify.annotations.Nullable;
 
 public class MultiblockCategory extends ViewerCategory<MultiblockCategory.Recipe> {
@@ -61,7 +56,7 @@ public class MultiblockCategory extends ViewerCategory<MultiblockCategory.Recipe
     @Override
     public void buildRecipes(RecipeManager recipeManager, RegistryAccess registryAccess, Consumer<Recipe> consumer) {
         for (ReiMachineRecipes.MultiblockShape entry : ReiMachineRecipes.multiblockShapes) {
-            consumer.accept(new Recipe(entry.machine(), entry.shapeTemplate(), entry.alternative()));
+            consumer.accept(new Recipe(entry.machine(), entry.shapeTemplate(), entry.alternative(), registryAccess));
         }
     }
 
@@ -88,21 +83,26 @@ public class MultiblockCategory extends ViewerCategory<MultiblockCategory.Recipe
         public final List<ItemStack> materials = new ArrayList<>();
         public final ResourceLocation id;
 
-        public Recipe(ResourceLocation controller, ShapeTemplate shapeTemplate, @Nullable String alternative) {
+        public Recipe(ResourceLocation controller, ShapeTemplate shapeTemplate, @Nullable String alternative, RegistryAccess registries) {
             this.controller = BuiltInRegistries.ITEM.get(controller).getDefaultInstance();
-            SortedMap<Item, Integer> materials = new TreeMap<>(Comparator.comparing(BuiltInRegistries.ITEM::getKey));
+            List<ItemStack> materials = new ArrayList<>();
 
+            outer:
             for (var entry : shapeTemplate.simpleMembers.entrySet()) {
-                BlockState state = entry.getValue().getPreviewState();
-                Item item = state.getBlock().asItem();
-                if (item != Items.AIR) {
-                    materials.put(item, 1 + materials.getOrDefault(item, 0));
+                var previewStack = entry.getValue().getItemPreviewState(registries).copy();
+                if (!previewStack.isEmpty()) {
+                    for (var materialStack : materials) {
+                        if (ItemStack.isSameItemSameComponents(materialStack, previewStack)) {
+                            materialStack.setCount(materialStack.getCount() + previewStack.getCount());
+                            continue outer;
+                        }
+                    }
+                    materials.add(previewStack);
                 }
             }
 
-            for (var entry : materials.entrySet()) {
-                this.materials.add(new ItemStack(entry.getKey(), entry.getValue()));
-            }
+            materials.sort(Comparator.comparing(ItemStack::getCount).reversed());
+            this.materials.addAll(materials);
             this.id = ResourceLocation.fromNamespaceAndPath(controller.getNamespace(),
                     "/" + controller.getPath() + "/" + materials.size() + (alternative == null ? "" : "/" + alternative));
         }

--- a/src/client/java/aztech/modern_industrialization/client/machines/multiblocks/MultiblockErrorHighlight.java
+++ b/src/client/java/aztech/modern_industrialization/client/machines/multiblocks/MultiblockErrorHighlight.java
@@ -27,6 +27,7 @@ package aztech.modern_industrialization.client.machines.multiblocks;
 import aztech.modern_industrialization.client.util.RenderHelper;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.ByteBufferBuilder;
+import com.mojang.datafixers.util.Pair;
 import java.util.HashMap;
 import java.util.Map;
 import net.minecraft.client.Minecraft;
@@ -34,22 +35,24 @@ import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
+import net.neoforged.neoforge.client.model.data.ModelData;
 import net.neoforged.neoforge.common.NeoForge;
 import org.jspecify.annotations.Nullable;
 
 public class MultiblockErrorHighlight {
-    private static final Map<BlockPos, @Nullable BlockState> highlightQueue = new HashMap<>();
+    private static final Map<BlockPos, @Nullable Pair<BlockState, @Nullable BlockEntity>> highlightQueue = new HashMap<>();
     private static final MultiBufferSource.BufferSource immediate = MultiBufferSource.immediate(new ByteBufferBuilder(128));
 
     public static void init() {
         NeoForge.EVENT_BUS.addListener(MultiblockErrorHighlight::end);
     }
 
-    public static void enqueueHighlight(BlockPos pos, @Nullable BlockState state) {
-        highlightQueue.put(pos.immutable(), state);
+    public static void enqueueHighlight(BlockPos pos, @Nullable BlockState state, @Nullable BlockEntity blockEntity) {
+        highlightQueue.put(pos.immutable(), state != null ? Pair.of(state, blockEntity) : null);
     }
 
     private static void end(RenderLevelStageEvent event) {
@@ -61,7 +64,7 @@ public class MultiblockErrorHighlight {
             var poseStack = event.getPoseStack();
             poseStack.pushPose();
             poseStack.mulPose(event.getModelViewMatrix());
-            for (Map.Entry<BlockPos, @Nullable BlockState> entry : highlightQueue.entrySet()) {
+            for (Map.Entry<BlockPos, @Nullable Pair<BlockState, @Nullable BlockEntity>> entry : highlightQueue.entrySet()) {
                 poseStack.pushPose();
                 Vec3 cameraPos = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition();
                 BlockPos pos = entry.getKey();
@@ -71,12 +74,19 @@ public class MultiblockErrorHighlight {
                 poseStack.translate(x + 0.25, y + 0.25, z + 0.25);
                 poseStack.scale(0.5f, 0.5f, 0.5f);
 
-                BlockState state = entry.getValue();
-                if (state == null) {
+                var value = entry.getValue();
+                if (value == null) {
                     RenderHelper.drawCube(poseStack, immediate, 1, 50f / 256, 50f / 256, LightTexture.FULL_BRIGHT, OverlayTexture.NO_OVERLAY);
                 } else {
-                    Minecraft.getInstance().getBlockRenderer().renderSingleBlock(state, poseStack, immediate, LightTexture.FULL_BRIGHT,
-                            OverlayTexture.NO_OVERLAY);
+                    BlockState state = value.getFirst();
+                    BlockEntity blockEntity = value.getSecond();
+                    var berDispatcher = Minecraft.getInstance().getBlockEntityRenderDispatcher();
+                    if (blockEntity != null && berDispatcher.getRenderer(blockEntity) != null) {
+                        berDispatcher.render(blockEntity, 0, poseStack, immediate);
+                    } else {
+                        ModelData modelData = blockEntity == null ? ModelData.EMPTY : blockEntity.getModelData();
+                        Minecraft.getInstance().getBlockRenderer().renderSingleBlock(state, poseStack, immediate, 15728880, OverlayTexture.NO_OVERLAY, modelData, null);
+                    }
                 }
 
                 poseStack.popPose();

--- a/src/client/java/aztech/modern_industrialization/client/machines/multiblocks/MultiblockMachineBER.java
+++ b/src/client/java/aztech/modern_industrialization/client/machines/multiblocks/MultiblockMachineBER.java
@@ -88,10 +88,13 @@ public class MultiblockMachineBER extends MachineBlockEntityRenderer<MultiblockM
                         var existingState = be.getLevel().getBlockState(pos);
                         if (existingState.isAir() || /* approximate check for e.g. grass and snow */ existingState.canBeReplaced()) {
                             // Enqueue state preview
-                            MultiblockErrorHighlight.enqueueHighlight(pos, matcher.getSimpleMember(pos).getPreviewState());
+                            var member = matcher.getSimpleMember(pos);
+                            var state = ShapeMatcher.toWorldState(be.getLevel(), pos, member.getPreviewState(), matcher.controllerDirection);
+                            var blockEntity = member.newBlockEntity(be.getLevel(), pos, state);
+                            MultiblockErrorHighlight.enqueueHighlight(pos, state, blockEntity);
                         } else {
                             // Enqueue red cube
-                            MultiblockErrorHighlight.enqueueHighlight(pos, null);
+                            MultiblockErrorHighlight.enqueueHighlight(pos, null, null);
                         }
                     }
                 }

--- a/src/client/java/aztech/modern_industrialization/client/machines/multiblocks/MultiblockMachineBER.java
+++ b/src/client/java/aztech/modern_industrialization/client/machines/multiblocks/MultiblockMachineBER.java
@@ -90,7 +90,7 @@ public class MultiblockMachineBER extends MachineBlockEntityRenderer<MultiblockM
                             // Enqueue state preview
                             var member = matcher.getSimpleMember(pos);
                             var state = ShapeMatcher.toWorldState(be.getLevel(), pos, member.getPreviewState(), matcher.controllerDirection);
-                            var blockEntity = member.newBlockEntity(be.getLevel(), pos, state);
+                            var blockEntity = member.newBlockEntity(be.getLevel().registryAccess(), be.getLevel(), pos, state);
                             MultiblockErrorHighlight.enqueueHighlight(pos, state, blockEntity);
                         } else {
                             // Enqueue red cube

--- a/src/main/java/aztech/modern_industrialization/guidebook/MultiblockShapeCompiler.java
+++ b/src/main/java/aztech/modern_industrialization/guidebook/MultiblockShapeCompiler.java
@@ -71,7 +71,8 @@ public class MultiblockShapeCompiler implements SceneElementTagCompiler {
         // Shape blocks
         for (var entry : shape.simpleMembers.entrySet()) {
             var pos = ShapeMatcher.toWorldPos(controllerPos, multi.orientation.facingDirection, entry.getKey());
-            scene.getLevel().setBlockAndUpdate(pos, entry.getValue().getPreviewState());
+            var state = ShapeMatcher.toWorldState(scene.getLevel(), pos, entry.getValue().getPreviewState(), multi.orientation.facingDirection);
+            scene.getLevel().setBlockAndUpdate(pos, state);
         }
         // Annotations for allowed hatches
         for (var entry : shape.hatchFlags.entrySet()) {

--- a/src/main/java/aztech/modern_industrialization/machines/components/ShapeValidComponent.java
+++ b/src/main/java/aztech/modern_industrialization/machines/components/ShapeValidComponent.java
@@ -25,8 +25,14 @@
 package aztech.modern_industrialization.machines.components;
 
 import aztech.modern_industrialization.machines.MachineComponent;
+import java.util.HashSet;
+import java.util.Set;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtUtils;
+import net.minecraft.nbt.Tag;
 
 /**
  * Syncing whether the multiblock shape is currently valid with the clients, to
@@ -36,12 +42,28 @@ public class ShapeValidComponent implements MachineComponent.ClientOnly {
     private boolean lastShapeValid = false;
     public boolean shapeValid = false;
 
+    private Set<BlockPos> lastMismatchingBlockEntities = new HashSet<>();
+    private Set<BlockPos> mismatchingBlockEntities = new HashSet<>();
+
+    public boolean isBlockEntityMatchingAt(BlockPos pos) {
+        return !mismatchingBlockEntities.contains(pos);
+    }
+
+    public void clearMismatchingBlockEntities() {
+        mismatchingBlockEntities.clear();
+    }
+
+    public void addMismatchingBlockEntity(BlockPos pos) {
+        mismatchingBlockEntities.add(pos);
+    }
+
     /**
      * Return true if this component should be synced with the client.
      */
     public boolean update() {
-        if (lastShapeValid != shapeValid) {
+        if (lastShapeValid != shapeValid || !lastMismatchingBlockEntities.equals(mismatchingBlockEntities)) {
             lastShapeValid = shapeValid;
+            lastMismatchingBlockEntities = Set.copyOf(mismatchingBlockEntities);
             return true;
         }
         return false;
@@ -50,10 +72,26 @@ public class ShapeValidComponent implements MachineComponent.ClientOnly {
     @Override
     public void writeClientNbt(CompoundTag tag, HolderLookup.Provider registries) {
         tag.putBoolean("shapeValid", shapeValid);
+
+        ListTag mismatchingBlockEntitiesTag = new ListTag();
+        for (BlockPos pos : mismatchingBlockEntities) {
+            CompoundTag blockTag = new CompoundTag();
+            blockTag.put("pos", NbtUtils.writeBlockPos(pos));
+            mismatchingBlockEntitiesTag.add(blockTag);
+        }
+        tag.put("mismatchingBlockEntities", mismatchingBlockEntitiesTag);
     }
 
     @Override
     public void readClientNbt(CompoundTag tag, HolderLookup.Provider registries) {
         shapeValid = tag.getBoolean("shapeValid");
+
+        mismatchingBlockEntities.clear();
+        ListTag mismatchingBlockEntitiesTag = tag.getList("mismatchingBlockEntities", Tag.TAG_COMPOUND);
+        for (Tag blockTag : mismatchingBlockEntitiesTag) {
+            if (blockTag instanceof CompoundTag blockCompoundTag) {
+                NbtUtils.readBlockPos(blockCompoundTag, "pos").ifPresent(mismatchingBlockEntities::add);
+            }
+        }
     }
 }

--- a/src/main/java/aztech/modern_industrialization/machines/components/ShapeValidComponent.java
+++ b/src/main/java/aztech/modern_industrialization/machines/components/ShapeValidComponent.java
@@ -42,6 +42,7 @@ public class ShapeValidComponent implements MachineComponent.ClientOnly {
     private boolean lastShapeValid = false;
     public boolean shapeValid = false;
 
+    // Used to communicate what block entities are mismatching to the client, since it does not have full block entity awareness like the server does
     private Set<BlockPos> lastMismatchingBlockEntities = new HashSet<>();
     private Set<BlockPos> mismatchingBlockEntities = new HashSet<>();
 

--- a/src/main/java/aztech/modern_industrialization/machines/multiblocks/MultiblockMachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/multiblocks/MultiblockMachineBlockEntity.java
@@ -51,7 +51,7 @@ public abstract class MultiblockMachineBlockEntity extends MachineBlockEntity {
     }
 
     public ShapeMatcher createShapeMatcher() {
-        return new ShapeMatcher(level, worldPosition, orientation.facingDirection, getActiveShape());
+        return new ShapeMatcher(level, worldPosition, orientation.facingDirection, getActiveShape(), shapeValid);
     }
 
     protected void onRematch(ShapeMatcher shapeMatcher) {}

--- a/src/main/java/aztech/modern_industrialization/machines/multiblocks/ShapeMatcher.java
+++ b/src/main/java/aztech/modern_industrialization/machines/multiblocks/ShapeMatcher.java
@@ -44,7 +44,7 @@ import org.jspecify.annotations.Nullable;
  * Status of a multiblock shape bound to some position and direction.
  */
 public class ShapeMatcher implements ChunkEventListener {
-    public ShapeMatcher(Level world, BlockPos controllerPos, Direction controllerDirection, ShapeTemplate template, @Nullable ShapeValidComponent shapeValid) {
+    public ShapeMatcher(Level world, BlockPos controllerPos, Direction controllerDirection, ShapeTemplate template, ShapeValidComponent shapeValid) {
         this.controllerPos = controllerPos;
         this.controllerDirection = controllerDirection;
         this.template = template;
@@ -56,7 +56,7 @@ public class ShapeMatcher implements ChunkEventListener {
     protected final BlockPos controllerPos;
     public final Direction controllerDirection;
     protected final ShapeTemplate template;
-    protected final @Nullable ShapeValidComponent shapeValid;
+    protected final ShapeValidComponent shapeValid;
     protected final Map<BlockPos, SimpleMember> simpleMembers;
     protected final Map<BlockPos, HatchFlags> hatchFlags;
 
@@ -146,9 +146,7 @@ public class ShapeMatcher implements ChunkEventListener {
         }
 
         matchedHatches.clear();
-        if (shapeValid != null) {
-            shapeValid.clearMismatchingBlockEntities();
-        }
+        shapeValid.clearMismatchingBlockEntities();
         matchSuccessful = false;
         needsRematch = true;
     }
@@ -173,7 +171,7 @@ public class ShapeMatcher implements ChunkEventListener {
 
         BlockState state = toTemplateState(world, pos, world.getBlockState(pos), controllerDirection);
         boolean matches = simpleMember.matchesState(state, be);
-        if (be != null && shapeValid != null) {
+        if (be != null) {
             if (world.isClientSide()) {
                 return shapeValid.isBlockEntityMatchingAt(pos);
             } else if (!matches) {

--- a/src/main/java/aztech/modern_industrialization/machines/multiblocks/ShapeMatcher.java
+++ b/src/main/java/aztech/modern_industrialization/machines/multiblocks/ShapeMatcher.java
@@ -26,6 +26,8 @@ package aztech.modern_industrialization.machines.multiblocks;
 
 import static net.minecraft.core.Direction.*;
 
+import aztech.modern_industrialization.blocks.FastBlockEntity;
+import aztech.modern_industrialization.machines.components.ShapeValidComponent;
 import aztech.modern_industrialization.machines.multiblocks.world.ChunkEventListener;
 import aztech.modern_industrialization.machines.multiblocks.world.ChunkEventListeners;
 import java.util.*;
@@ -33,6 +35,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jspecify.annotations.Nullable;
@@ -41,15 +44,19 @@ import org.jspecify.annotations.Nullable;
  * Status of a multiblock shape bound to some position and direction.
  */
 public class ShapeMatcher implements ChunkEventListener {
-    public ShapeMatcher(Level world, BlockPos controllerPos, Direction controllerDirection, ShapeTemplate template) {
+    public ShapeMatcher(Level world, BlockPos controllerPos, Direction controllerDirection, ShapeTemplate template, @Nullable ShapeValidComponent shapeValid) {
         this.controllerPos = controllerPos;
+        this.controllerDirection = controllerDirection;
         this.template = template;
+        this.shapeValid = shapeValid;
         this.simpleMembers = toWorldPos(controllerPos, controllerDirection, template.simpleMembers);
         this.hatchFlags = toWorldPos(controllerPos, controllerDirection, template.hatchFlags);
     }
 
     protected final BlockPos controllerPos;
+    public final Direction controllerDirection;
     protected final ShapeTemplate template;
+    protected final @Nullable ShapeValidComponent shapeValid;
     protected final Map<BlockPos, SimpleMember> simpleMembers;
     protected final Map<BlockPos, HatchFlags> hatchFlags;
 
@@ -82,6 +89,40 @@ public class ShapeMatcher implements ChunkEventListener {
         return result;
     }
 
+    private static Rotation templateRotation(Direction controllerDirection) {
+        return switch (controllerDirection) {
+            case SOUTH -> Rotation.NONE;
+            case NORTH -> Rotation.CLOCKWISE_180;
+            case EAST -> Rotation.CLOCKWISE_90;
+            case WEST -> Rotation.COUNTERCLOCKWISE_90;
+            default -> throw new IllegalStateException("Unexpected value: " + controllerDirection);
+        };
+    }
+
+    private static Rotation worldRotation(Direction controllerDirection) {
+        return switch (controllerDirection) {
+            case SOUTH -> Rotation.NONE;
+            case NORTH -> Rotation.CLOCKWISE_180;
+            case EAST -> Rotation.COUNTERCLOCKWISE_90;
+            case WEST -> Rotation.CLOCKWISE_90;
+            default -> throw new IllegalStateException("Unexpected value: " + controllerDirection);
+        };
+    }
+
+    /**
+     * Convert a in-world block state to a rotated block state as it should be saved for a shape template.
+     */
+    public static BlockState toTemplateState(Level level, BlockPos pos, BlockState state, Direction controllerDirection) {
+        return state.rotate(level, pos, templateRotation(controllerDirection));
+    }
+
+    /**
+     * Convert a template block state to a rotated block state as it should be placed in world.
+     */
+    public static BlockState toWorldState(Level level, BlockPos pos, BlockState state, Direction controllerDirection) {
+        return state.rotate(level, pos, worldRotation(controllerDirection));
+    }
+
     public Set<BlockPos> getPositions() {
         return new HashSet<>(simpleMembers.keySet());
     }
@@ -105,6 +146,9 @@ public class ShapeMatcher implements ChunkEventListener {
         }
 
         matchedHatches.clear();
+        if (shapeValid != null) {
+            shapeValid.clearMismatchingBlockEntities();
+        }
         matchSuccessful = false;
         needsRematch = true;
     }
@@ -118,10 +162,6 @@ public class ShapeMatcher implements ChunkEventListener {
         if (simpleMember == null)
             return false;
 
-        BlockState state = world.getBlockState(pos);
-        if (simpleMember.matchesState(state))
-            return true;
-
         BlockEntity be = world.getBlockEntity(pos);
         if (be instanceof HatchBlockEntity hatch) {
             HatchFlags flags = hatchFlags.get(pos);
@@ -131,7 +171,16 @@ public class ShapeMatcher implements ChunkEventListener {
             }
         }
 
-        return false;
+        BlockState state = toTemplateState(world, pos, world.getBlockState(pos), controllerDirection);
+        boolean matches = simpleMember.matchesState(state, be);
+        if (be != null && shapeValid != null) {
+            if (world.isClientSide()) {
+                return shapeValid.isBlockEntityMatchingAt(pos);
+            } else if (!matches) {
+                shapeValid.addMismatchingBlockEntity(pos);
+            }
+        }
+        return matches;
     }
 
     public boolean needsRematch() {
@@ -196,9 +245,21 @@ public class ShapeMatcher implements ChunkEventListener {
         int setBlocks = 0;
 
         for (var entry : simpleMembers.entrySet()) {
-            var current = level.getBlockState(entry.getKey());
-            if (!entry.getValue().matchesState(current)) {
-                level.setBlockAndUpdate(entry.getKey(), entry.getValue().getPreviewState());
+            var pos = entry.getKey();
+            var member = entry.getValue();
+            var currentState = level.getBlockState(entry.getKey());
+            var currentBlockEntity = level.getBlockEntity(entry.getKey());
+            if (!member.matchesState(currentState, currentBlockEntity)) {
+                var placeState = toWorldState(level, pos, member.getPreviewState(), controllerDirection);
+                var placeBlockEntity = member.newBlockEntity(level, pos, placeState);
+                level.setBlockAndUpdate(pos, placeState);
+                if (placeBlockEntity != null) {
+                    level.setBlockEntity(placeBlockEntity);
+                    placeBlockEntity.setChanged();
+                    if (placeBlockEntity instanceof FastBlockEntity fbe) {
+                        fbe.sync();
+                    }
+                }
                 ++setBlocks;
             }
         }

--- a/src/main/java/aztech/modern_industrialization/machines/multiblocks/ShapeMatcher.java
+++ b/src/main/java/aztech/modern_industrialization/machines/multiblocks/ShapeMatcher.java
@@ -249,7 +249,7 @@ public class ShapeMatcher implements ChunkEventListener {
             var currentBlockEntity = level.getBlockEntity(entry.getKey());
             if (!member.matchesState(currentState, currentBlockEntity)) {
                 var placeState = toWorldState(level, pos, member.getPreviewState(), controllerDirection);
-                var placeBlockEntity = member.newBlockEntity(level, pos, placeState);
+                var placeBlockEntity = member.newBlockEntity(level.registryAccess(), level, pos, placeState);
                 level.setBlockAndUpdate(pos, placeState);
                 if (placeBlockEntity != null) {
                     level.setBlockEntity(placeBlockEntity);

--- a/src/main/java/aztech/modern_industrialization/machines/multiblocks/SimpleMember.java
+++ b/src/main/java/aztech/modern_industrialization/machines/multiblocks/SimpleMember.java
@@ -28,8 +28,10 @@ import java.util.Objects;
 import java.util.function.Supplier;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -46,9 +48,13 @@ public interface SimpleMember {
     boolean matchesState(BlockState state, @Nullable BlockEntity blockEntity);
 
     @Nullable
-    BlockEntity newBlockEntity(Level level, BlockPos pos, BlockState state);
+    BlockEntity newBlockEntity(RegistryAccess registries, @Nullable Level level, BlockPos pos, BlockState state);
 
     BlockState getPreviewState();
+
+    default ItemStack getItemPreviewState(RegistryAccess registries) {
+        return this.getPreviewState().getBlock().asItem().getDefaultInstance();
+    }
 
     static SimpleMember forBlock(Supplier<? extends Block> block) {
         Objects.requireNonNull(block);
@@ -60,7 +66,7 @@ public interface SimpleMember {
             }
 
             @Override
-            public @Nullable BlockEntity newBlockEntity(Level level, BlockPos pos, BlockState state) {
+            public @Nullable BlockEntity newBlockEntity(RegistryAccess registries, @Nullable Level level, BlockPos pos, BlockState state) {
                 return null;
             }
 
@@ -85,7 +91,7 @@ public interface SimpleMember {
             }
 
             @Override
-            public @Nullable BlockEntity newBlockEntity(Level level, BlockPos pos, BlockState state) {
+            public @Nullable BlockEntity newBlockEntity(RegistryAccess registries, @Nullable Level level, BlockPos pos, BlockState state) {
                 return null;
             }
 
@@ -104,7 +110,7 @@ public interface SimpleMember {
             }
 
             @Override
-            public @Nullable BlockEntity newBlockEntity(Level level, BlockPos pos, BlockState state) {
+            public @Nullable BlockEntity newBlockEntity(RegistryAccess registries, @Nullable Level level, BlockPos pos, BlockState state) {
                 return null;
             }
 

--- a/src/main/java/aztech/modern_industrialization/machines/multiblocks/SimpleMember.java
+++ b/src/main/java/aztech/modern_industrialization/machines/multiblocks/SimpleMember.java
@@ -26,20 +26,27 @@ package aztech.modern_industrialization.machines.multiblocks;
 
 import java.util.Objects;
 import java.util.function.Supplier;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.RotatedPillarBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The representation of a simple logic-less member that is part of a shape,
  * e.g. a casing.
  */
 public interface SimpleMember {
-    boolean matchesState(BlockState state);
+    boolean matchesState(BlockState state, @Nullable BlockEntity blockEntity);
+
+    @Nullable
+    BlockEntity newBlockEntity(Level level, BlockPos pos, BlockState state);
 
     BlockState getPreviewState();
 
@@ -48,8 +55,13 @@ public interface SimpleMember {
 
         return new SimpleMember() {
             @Override
-            public boolean matchesState(BlockState state) {
+            public boolean matchesState(BlockState state, @Nullable BlockEntity blockEntity) {
                 return state.is(block.get());
+            }
+
+            @Override
+            public @Nullable BlockEntity newBlockEntity(Level level, BlockPos pos, BlockState state) {
+                return null;
             }
 
             @Override
@@ -68,8 +80,13 @@ public interface SimpleMember {
 
         return new SimpleMember() {
             @Override
-            public boolean matchesState(BlockState state2) {
+            public boolean matchesState(BlockState state2, @Nullable BlockEntity blockEntity) {
                 return state == state2;
+            }
+
+            @Override
+            public @Nullable BlockEntity newBlockEntity(Level level, BlockPos pos, BlockState state) {
+                return null;
             }
 
             @Override
@@ -82,8 +99,13 @@ public interface SimpleMember {
     static SimpleMember verticalChain() {
         return new SimpleMember() {
             @Override
-            public boolean matchesState(BlockState state) {
+            public boolean matchesState(BlockState state, @Nullable BlockEntity blockEntity) {
                 return state.is(Blocks.CHAIN) && state.getValue(RotatedPillarBlock.AXIS) == Direction.Axis.Y;
+            }
+
+            @Override
+            public @Nullable BlockEntity newBlockEntity(Level level, BlockPos pos, BlockState state) {
+                return null;
             }
 
             @Override


### PR DESCRIPTION
Supersedes #1162 and #932 

I believe this to be the bare minimum changes required in MI to support rotatable `BlockState`s (stairs for example) and specific `BlockEntity` matching (framed blocks/copycats for example). The previous PRs were a bit overambitious.

I understand the port to 26.1 is in progress. I and a few others would like to see this functionality available in 1.21.1, but I understand if you do not want to add new features to 1.21.1 at this point. If it would help convince you at all, I would be more than willing to open a PR to port this to 26.1 as well once that is in a workable state.