### PR TITLE
Don't enable FTB Quests integration by default

### DIFF
--- a/src/main/java/aztech/modern_industrialization/config/MIStartupConfig.java
+++ b/src/main/java/aztech/modern_industrialization/config/MIStartupConfig.java
@@ -73,7 +73,7 @@ public final class MIStartupConfig {
                 "FTB Quests integration",
                 "Enable the FTB Quests integration, if present.")
                 .gameRestart()
-                .define("ftbQuestsIntegration", true);
+                .define("ftbQuestsIntegration", false);
         this.almostUnifiedIntegration = builder.start("almostUnifiedIntegration",
                 "Almost Unified integration",
                 "Enable the Almost Unified integration, if present.")


### PR DESCRIPTION
There have been numerous instances of people having lag where just turning this option off significantly improves it. Most people do not use this, or even are aware it exists, so I believe it is best to disable it by default.