### PR TITLE
Include config translation keys for transactionCallerName option

### DIFF
--- a/src/generated/resources/.cache/8ad8302d110b05d7e02330dac58628134fdcff02
+++ b/src/generated/resources/.cache/8ad8302d110b05d7e02330dac58628134fdcff02
@@ -1,2 +1,2 @@
-// 1.21.1	2025-11-01T11:09:54.2591146	Translations
-f87606b94e232a6ec16249c4d3703f292e428690 assets/modern_industrialization/lang/en_us.json
+// 1.21.1	2026-06-27T23:36:23.865522938	Translations
+0bf1c8620c1c6a6ef051bdd15e1a9c806be532e4 assets/modern_industrialization/lang/en_us.json

--- a/src/generated/resources/assets/modern_industrialization/lang/en_us.json
+++ b/src/generated/resources/assets/modern_industrialization/lang/en_us.json
@@ -1150,6 +1150,8 @@
   "modern_industrialization.configuration.stonecutterToCuttingMachine": "Stonecutter cutting machine recipes",
   "modern_industrialization.configuration.stonecutterToCuttingMachine.tooltip": "Generate cutting machine recipes for all stonecutter recipes.",
   "modern_industrialization.configuration.tooltips": "Tooltips",
+  "modern_industrialization.configuration.transactionCallerName": "Include Transaction Caller Name",
+  "modern_industrialization.configuration.transactionCallerName.tooltip": "Enable to have transfer transactions include the name of the class that called it. Note that this comes at the cost of performance. It is recommended to not use this outside of debugging.",
   "rei_categories.modern_industrialization.assembler": "Assembler",
   "rei_categories.modern_industrialization.bronze_compressor": "Compressor",
   "rei_categories.modern_industrialization.bronze_cutting_machine": "Cutting Machine",


### PR DESCRIPTION
Was forgotten in #1250