### PR TITLE
Fix barrel contents getting out of sync

### DIFF
--- a/src/main/java/aztech/modern_industrialization/blocks/storage/AbstractStorageBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/blocks/storage/AbstractStorageBlockEntity.java
@@ -27,12 +27,14 @@ package aztech.modern_industrialization.blocks.storage;
 import aztech.modern_industrialization.MIText;
 import aztech.modern_industrialization.blocks.FastBlockEntity;
 import aztech.modern_industrialization.blocks.WrenchableBlockEntity;
+import aztech.modern_industrialization.thirdparty.fabrictransfer.api.item.ItemVariant;
 import aztech.modern_industrialization.thirdparty.fabrictransfer.api.storage.StoragePreconditions;
 import aztech.modern_industrialization.thirdparty.fabrictransfer.api.storage.TransferVariant;
 import aztech.modern_industrialization.thirdparty.fabrictransfer.api.storage.base.ResourceAmount;
 import aztech.modern_industrialization.thirdparty.fabrictransfer.api.storage.base.SingleSlotStorage;
 import aztech.modern_industrialization.thirdparty.fabrictransfer.api.transaction.SnapshotJournal;
 import aztech.modern_industrialization.thirdparty.fabrictransfer.api.transaction.TransactionContext;
+import com.google.common.primitives.Ints;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponentMap;
@@ -45,6 +47,7 @@ import net.minecraft.world.Clearable;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
@@ -62,6 +65,9 @@ public abstract class AbstractStorageBlockEntity<T extends TransferVariant<?>> e
     protected long amount;
     private long version;
     private boolean isLocked;
+
+    // Only used when T extends ItemVariant
+    private @Nullable ItemStack cachedItemStack;
 
     public final StorageBehaviour<T> behaviour;
 
@@ -122,6 +128,16 @@ public abstract class AbstractStorageBlockEntity<T extends TransferVariant<?>> e
         return !behaviour.isCreative();
     }
 
+    public ItemStack getItemStack() {
+        if (cachedItemStack == null) {
+            if (!(resource instanceof ItemVariant itemResource)) {
+                throw new IllegalStateException("Cannot get ItemStack of non-item storage");
+            }
+            cachedItemStack = amount == 0 ? ItemStack.EMPTY : itemResource.toStack(Ints.saturatedCast(amount));
+        }
+        return cachedItemStack;
+    }
+
     public long insert(T resource, long maxAmount, TransactionContext transaction, boolean ignoreLock) {
         StoragePreconditions.notBlankNotNegative(resource, maxAmount);
 
@@ -135,6 +151,7 @@ public abstract class AbstractStorageBlockEntity<T extends TransferVariant<?>> e
                 participant.updateSnapshots(transaction);
                 amount += inserted;
                 this.resource = resource;
+                cachedItemStack = null;
             }
             return inserted;
         }
@@ -161,6 +178,7 @@ public abstract class AbstractStorageBlockEntity<T extends TransferVariant<?>> e
                     if (amount == 0 && !isLocked()) {
                         this.resource = getBlankResource();
                     }
+                    cachedItemStack = null;
                 }
                 return extracted;
             }
@@ -213,6 +231,7 @@ public abstract class AbstractStorageBlockEntity<T extends TransferVariant<?>> e
         protected void revertToSnapshot(ResourceAmount<T> snapshot) {
             resource = snapshot.resource();
             amount = snapshot.amount();
+            cachedItemStack = null;
         }
 
         @Override
@@ -256,6 +275,7 @@ public abstract class AbstractStorageBlockEntity<T extends TransferVariant<?>> e
             if (!behaviour.isCreative()) {
                 amount = storage.amount();
             }
+            cachedItemStack = null;
         }
     }
 
@@ -291,6 +311,8 @@ public abstract class AbstractStorageBlockEntity<T extends TransferVariant<?>> e
                 amount = 0;
             }
         }
+
+        cachedItemStack = null;
     }
 
     @Override
@@ -307,6 +329,7 @@ public abstract class AbstractStorageBlockEntity<T extends TransferVariant<?>> e
 
     public void setResource(T resource) {
         this.resource = resource;
+        cachedItemStack = null;
     }
 
     public abstract DataComponentType<ResourceStorage<T>> componentType();

--- a/src/main/java/aztech/modern_industrialization/thirdparty/fabrictransfer/api/bridge/SlotItemHandler.java
+++ b/src/main/java/aztech/modern_industrialization/thirdparty/fabrictransfer/api/bridge/SlotItemHandler.java
@@ -24,6 +24,7 @@
 
 package aztech.modern_industrialization.thirdparty.fabrictransfer.api.bridge;
 
+import aztech.modern_industrialization.blocks.storage.AbstractStorageBlockEntity;
 import aztech.modern_industrialization.inventory.FilledItemStorage;
 import aztech.modern_industrialization.thirdparty.fabrictransfer.api.item.ItemVariant;
 import aztech.modern_industrialization.thirdparty.fabrictransfer.api.storage.base.SingleSlotStorage;
@@ -31,14 +32,11 @@ import aztech.modern_industrialization.thirdparty.fabrictransfer.api.transaction
 import com.google.common.primitives.Ints;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.items.IItemHandler;
-import org.jspecify.annotations.Nullable;
 
 public final class SlotItemHandler implements IItemHandler, FilledItemStorage {
-    private final SingleSlotStorage<ItemVariant> storage;
+    private final AbstractStorageBlockEntity<ItemVariant> storage;
 
-    private @Nullable ItemStack cachedItemStack;
-
-    public SlotItemHandler(SingleSlotStorage<ItemVariant> storage) {
+    public SlotItemHandler(AbstractStorageBlockEntity<ItemVariant> storage) {
         this.storage = storage;
     }
 
@@ -53,10 +51,7 @@ public final class SlotItemHandler implements IItemHandler, FilledItemStorage {
 
     @Override
     public ItemStack getStackInSlot(int slot) {
-        if (cachedItemStack == null) {
-            cachedItemStack = storage.getResource().toStack(Ints.saturatedCast(storage.getAmount()));
-        }
-        return cachedItemStack;
+        return storage.getItemStack();
     }
 
     @Override
@@ -68,9 +63,6 @@ public final class SlotItemHandler implements IItemHandler, FilledItemStorage {
             var inserted = storage.insert(ItemVariant.of(stack), stack.getCount(), tx);
             if (!simulate) {
                 tx.commit();
-                if (inserted > 0) {
-                    cachedItemStack = null;
-                }
             }
             return inserted == 0 ? stack : stack.copyWithCount(stack.getCount() - (int) inserted);
         }
@@ -89,9 +81,6 @@ public final class SlotItemHandler implements IItemHandler, FilledItemStorage {
             var extracted = storage.extract(resource, amount, tx);
             if (!simulate) {
                 tx.commit();
-                if (extracted > 0) {
-                    cachedItemStack = null;
-                }
             }
             return extracted == 0 ? ItemStack.EMPTY : resource.toStack((int) extracted);
         }


### PR DESCRIPTION
Introduced by #1249, and irrelevant for 26.1+

This problem happens when the wrapped storage in `SlotItemHandler` is modified instead of the `SlotItemHandler` itself being modified. Unfortunately quite a bit of the code still uses the Fabric Transfer API in 1.21.1, so this seems unavoidable.

The patch is a bit hacky, but the inner storage now caches the `ItemStack` instead. This is significantly more reliable.