### PR TITLE
Fix some solid blocks that have transparent pixels allowing to see through blocks

### DIFF
--- a/src/generated/resources/.cache/5bd35c4697ddab07a78a22a127c645fe1d695c45
+++ b/src/generated/resources/.cache/5bd35c4697ddab07a78a22a127c645fe1d695c45
@@ -1,4 +1,4 @@
-// 1.21.1	2026-06-30T18:58:33.679616329	Tags for minecraft:block mod id modern_industrialization
+// 1.21.1	2026-07-09T08:12:33.598692837	Tags for minecraft:block mod id modern_industrialization
 ef72297aa0ecfbc2672c0b74167d4bf1fa4b262e data/c/tags/block/ores.json
 b74bc7a6e8507c54ded11660bf60f4e7e06910a0 data/c/tags/block/ores/antimony.json
 692748c1f1e0425903fdf4da21c318c4c4a739bb data/c/tags/block/ores/bauxite.json
@@ -72,4 +72,4 @@ ba09e47df7025bb1c4d4a072a54ce0b2e307f003 data/c/tags/block/storage_blocks/yttriu
 0598637f8fa446913456c69504f5c6bc1a6b19f1 data/minecraft/tags/block/needs_stone_tool.json
 2f4942034efc4f0ca583b4947ecf67ae3ee08540 data/modern_industrialization/tags/block/barrels.json
 ed3e8137fcabedef6118d8d5980c348ad5ef1d22 data/modern_industrialization/tags/block/tanks.json
-04cebeb2d742fe55d77908d1bb3829e25f9a8549 data/modern_industrialization/tags/block/transparent_pipe_camouflage.json
+503db4170600aaf58e5984fe23343a736046e18c data/modern_industrialization/tags/block/transparent_pipe_camouflage.json

--- a/src/generated/resources/data/modern_industrialization/tags/block/transparent_pipe_camouflage.json
+++ b/src/generated/resources/data/modern_industrialization/tags/block/transparent_pipe_camouflage.json
@@ -1,6 +1,17 @@
 {
   "values": [
     "#c:glass_blocks",
-    "#minecraft:leaves"
+    "#minecraft:leaves",
+    "minecraft:mangrove_roots",
+    "minecraft:slime_block",
+    "minecraft:honey_block",
+    "minecraft:copper_grate",
+    "minecraft:exposed_copper_grate",
+    "minecraft:weathered_copper_grate",
+    "minecraft:oxidized_copper_grate",
+    "minecraft:waxed_copper_grate",
+    "minecraft:waxed_exposed_copper_grate",
+    "minecraft:waxed_weathered_copper_grate",
+    "minecraft:waxed_oxidized_copper_grate"
   ]
 }

--- a/src/main/java/aztech/modern_industrialization/datagen/tag/MIBlockTagProvider.java
+++ b/src/main/java/aztech/modern_industrialization/datagen/tag/MIBlockTagProvider.java
@@ -37,6 +37,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.data.BlockTagsProvider;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
@@ -56,7 +57,11 @@ public class MIBlockTagProvider extends BlockTagsProvider {
             }
         }
 
-        tag(MITags.TRANSPARENT_PIPE_CAMOUFLAGE).addTags(Tags.Blocks.GLASS_BLOCKS, BlockTags.LEAVES);
+        tag(MITags.TRANSPARENT_PIPE_CAMOUFLAGE)
+                .addTags(Tags.Blocks.GLASS_BLOCKS, BlockTags.LEAVES)
+                .add(Blocks.MANGROVE_ROOTS, Blocks.SLIME_BLOCK, Blocks.HONEY_BLOCK)
+                .add(Blocks.COPPER_GRATE, Blocks.EXPOSED_COPPER_GRATE, Blocks.WEATHERED_COPPER_GRATE, Blocks.OXIDIZED_COPPER_GRATE)
+                .add(Blocks.WAXED_COPPER_GRATE, Blocks.WAXED_EXPOSED_COPPER_GRATE, Blocks.WAXED_WEATHERED_COPPER_GRATE, Blocks.WAXED_OXIDIZED_COPPER_GRATE);
         tag(BlockTags.MINEABLE_WITH_PICKAXE).add(MIPipes.BLOCK_PIPE.get());
         tag(Tags.Blocks.RELOCATION_NOT_SUPPORTED).add(MIPipes.BLOCK_PIPE.get());
 


### PR DESCRIPTION
For example mangrove roots and slime blocks are considered solid and valid camouflage, but would allow seeing through the world.

This also makes honey blocks + copper grates valid for pipe camouflage.