### PR TITLE
Make Steam Drill mine at diamond tool level rather than netherite

### DIFF
--- a/src/main/java/aztech/modern_industrialization/items/SteamDrillItem.java
+++ b/src/main/java/aztech/modern_industrialization/items/SteamDrillItem.java
@@ -151,7 +151,7 @@ public class SteamDrillItem
 
     @Override
     public boolean isCorrectToolForDrops(ItemStack stack, BlockState state) {
-        if (isSupportedBlock(stack, state) && canUse(stack) && !state.is(Tiers.NETHERITE.getIncorrectBlocksForDrops())) {
+        if (isSupportedBlock(stack, state) && canUse(stack) && !state.is(Tiers.DIAMOND.getIncorrectBlocksForDrops())) {
             return true;
         }
         return super.isCorrectToolForDrops(stack, state);


### PR DESCRIPTION
The diesel drill makes sense to be netherite tier, but not the steam drill.