### PR TITLE
Swap to gnomecraft maven repository for EMI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,9 +56,8 @@ repositories {
         }
     }
     maven {
-        url "https://maven.terraformersmc.com"
+        url "https://maven.gnomecraft.net/repository/maven-public"
         content {
-            includeGroup "com.terraformersmc"
             includeGroup "dev.emi"
         }
     }


### PR DESCRIPTION
TerraformersMC maven repository has been flaky as of late (TerraformersMC/ModMenu#1069). Gnomecraft is a mirror that lets us keep the dependency target intact while also being more reliable.