### PR TITLE
Improve machine insert item performance

### DIFF
--- a/src/main/java/aztech/modern_industrialization/inventory/MIItemStorage.java
+++ b/src/main/java/aztech/modern_industrialization/inventory/MIItemStorage.java
@@ -65,7 +65,7 @@ public class MIItemStorage extends MIStorage<Item, ItemVariant, ConfigurableItem
             // A bit messy, but lets us avoid always getting an ItemVariant which takes unnecessary time with a map lookup.
             ItemVariant resource = null;
             boolean canInsert;
-            if (stack.amount == 0) {
+            if (stack.getAmount() == 0) {
                 // If the amount is 0, we check if the lock allows it.
                 canInsert = stack.isResourceAllowedByLock(item.getItem());
             } else if ((item.isEmpty() || item.isComponentsPatchEmpty()) && (stack.isEmpty() || stack.getResource().getComponentsPatch().isEmpty())) {

--- a/src/main/java/aztech/modern_industrialization/inventory/MIItemStorage.java
+++ b/src/main/java/aztech/modern_industrialization/inventory/MIItemStorage.java
@@ -134,7 +134,7 @@ public class MIItemStorage extends MIStorage<Item, ItemVariant, ConfigurableItem
         @Override
         public void getWhitelistedItems(Set<Item> whitelist) {
             for (ConfigurableItemStack stack : stacks) {
-                if (stack.pipesInsert && stack.getLockedInstance() != Items.AIR) {
+                if (stack.pipesInsert && !stack.isLockedTo(Items.AIR) && stack.getAmount() < stack.getCapacity()) {
                     whitelist.add(stack.getLockedInstance());
                 }
             }

--- a/src/main/java/aztech/modern_industrialization/inventory/MIItemStorage.java
+++ b/src/main/java/aztech/modern_industrialization/inventory/MIItemStorage.java
@@ -62,14 +62,17 @@ public class MIItemStorage extends MIStorage<Item, ItemVariant, ConfigurableItem
                 return item;
             }
 
-            // A bit messy, but lets us avoid always getting an ItemVariant which takes unnecessary time with a map lookup
+            // A bit messy, but lets us avoid always getting an ItemVariant which takes unnecessary time with a map lookup.
             ItemVariant resource = null;
             boolean canInsert;
             if (stack.amount == 0) {
+                // If the amount is 0, we check if the lock allows it.
                 canInsert = stack.isResourceAllowedByLock(item.getItem());
             } else if ((item.isEmpty() || item.isComponentsPatchEmpty()) && (stack.isEmpty() || stack.getResource().getComponentsPatch().isEmpty())) {
+                // If both items don't have components, we check if they are the same item.
                 canInsert = item.is(stack.getResource().getItem());
             } else {
+                // Otherwise we check that the resources match exactly.
                 resource = ItemVariant.of(item);
                 canInsert = stack.getResource().equals(resource);
             }

--- a/src/main/java/aztech/modern_industrialization/inventory/MIItemStorage.java
+++ b/src/main/java/aztech/modern_industrialization/inventory/MIItemStorage.java
@@ -62,19 +62,22 @@ public class MIItemStorage extends MIStorage<Item, ItemVariant, ConfigurableItem
                 return item;
             }
 
-            ItemVariant resource = ItemVariant.of(item);
-
+            // A bit messy, but lets us avoid always getting an ItemVariant which takes unnecessary time with a map lookup
+            ItemVariant resource = null;
             boolean canInsert;
-
-            if (stack.getAmount() == 0) {
-                // If the amount is 0, we check if the lock allows it.
-                canInsert = stack.isResourceAllowedByLock(resource);
+            if (stack.amount == 0) {
+                canInsert = stack.isResourceAllowedByLock(item.getItem());
+            } else if ((item.isEmpty() || item.isComponentsPatchEmpty()) && (stack.isEmpty() || stack.getResource().getComponentsPatch().isEmpty())) {
+                canInsert = item.is(stack.getResource().getItem());
             } else {
-                // Otherwise we check that the resources match exactly.
+                resource = ItemVariant.of(item);
                 canInsert = stack.getResource().equals(resource);
             }
 
             if (canInsert) {
+                if (resource == null) {
+                    resource = ItemVariant.of(item);
+                }
                 long inserted = Math.min(item.getCount(), stack.getRemainingCapacityFor(resource));
 
                 if (inserted > 0 && !simulate) {

--- a/src/main/java/aztech/modern_industrialization/inventory/MIItemStorage.java
+++ b/src/main/java/aztech/modern_industrialization/inventory/MIItemStorage.java
@@ -134,7 +134,7 @@ public class MIItemStorage extends MIStorage<Item, ItemVariant, ConfigurableItem
         @Override
         public void getWhitelistedItems(Set<Item> whitelist) {
             for (ConfigurableItemStack stack : stacks) {
-                if (stack.pipesInsert && !stack.isLockedTo(Items.AIR) && stack.getAmount() < stack.getCapacity()) {
+                if (stack.pipesInsert && !stack.isLockedTo(Items.AIR)) {
                     whitelist.add(stack.getLockedInstance());
                 }
             }


### PR DESCRIPTION
A bit messy, but it does help situations with large pipe networks transferring lots of items. This lets the insert fail without getting an `ItemVariant`, which can take some time due to a map lookup.