### PR TITLE
Do not modify the item stacks of machine recipe ingredients

### DIFF
--- a/src/main/java/aztech/modern_industrialization/machines/recipe/MachineRecipe.java
+++ b/src/main/java/aztech/modern_industrialization/machines/recipe/MachineRecipe.java
@@ -154,15 +154,11 @@ public class MachineRecipe implements Recipe<RecipeInput> {
     @Override
     public NonNullList<Ingredient> getIngredients() {
         // This function is implemented for AE2 pattern shift-clicking compat.
-        // This is the reason the counts of the ItemStacks in the ingredient are
-        // modified.
-        // (They should never be used somewhere else anyway)
-        return new DefaultedListWrapper<>(itemInputs.stream().filter(i -> i.probability == 1).map(i -> {
-            for (ItemStack stack : i.ingredient.getItems()) {
-                stack.setCount(i.amount);
-            }
-            return i.ingredient;
-        }).collect(Collectors.toList()));
+        // The item stacks in the ingredient are copied with the correct count
+        // instead of being modified in place, because some mods (e.g. AllTheLeaks)
+        // cache and lock the item stacks of ingredients.
+        return new DefaultedListWrapper<>(itemInputs.stream().filter(i -> i.probability == 1).map(i -> Ingredient.of(
+                Arrays.stream(i.ingredient.getItems()).map(stack -> stack.copyWithCount(i.amount)))).collect(Collectors.toList()));
     }
 
     @Override


### PR DESCRIPTION
## Problem

`MachineRecipe#getIngredients()` modified the counts of the original `ItemStack`s inside the ingredient, which was done for AE2 pattern shift-clicking compat.

This is not allowed: AllTheLeaks (and potentially other mods) caches and locks the `ItemStack`s contained in ingredients, so mutating them throws `ATLUnsupportedOperation` and crashes the server at startup when both mods are installed.

## Fix

Instead of mutating the original stacks, the ingredient is rebuilt from copies (`stack.copyWithCount(i.amount)`) that carry the correct counts. The original ingredients are left untouched, which enhances compatibility with ingredient-locking mods such as AllTheLeaks, while AE2 still receives the correct amounts for pattern auto-filling.

## Testing

- `compileJava`, `immaculateCheck` and `licenseCheck` pass
- Tested in-game with AllTheLeaks present: no crash
- Verified AE2 pattern encoding for recipes with multiple items per input slot (e.g. 2x iron dust in the invar mixer recipe) still fills the correct amounts
