### PR TITLE
Fix steel upgrades being consumed for machines that do not include "bronze_" in their id

### DIFF
--- a/src/main/java/aztech/modern_industrialization/items/SteelUpgradeItem.java
+++ b/src/main/java/aztech/modern_industrialization/items/SteelUpgradeItem.java
@@ -64,6 +64,9 @@ public class SteelUpgradeItem extends Item {
         // Find new block
         Block block = context.getLevel().getBlockState(context.getClickedPos()).getBlock();
         ResourceLocation blockKey = BuiltInRegistries.BLOCK.getKey(block);
+        if (!blockKey.getPath().contains("bronze_")) {
+            return super.useOn(context);
+        }
         ResourceLocation newBlock = blockKey.withPath(p -> p.replace("bronze_", "steel_"));
         if (!BuiltInRegistries.BLOCK.containsKey(newBlock)) {
             return super.useOn(context);


### PR DESCRIPTION
In the case of machines that do not have `bronze_` included in their ID, the check for a block such that `bronze_` replaced with `steel_` exists would always succeed (since no change is made to the ID). This results in the steel upgrade item being consumed when using it on such a machine, while no change to the machine takes place.

This is merely a bandaid fix. The code steel upgrades have for determining a steel machine variant of a bronze machine "works". Though it is rather hacky, and could definitely benefit from a rewrite. Perhaps some method on a shared interface could be used to find the steel version of a machine.