### PR TITLE
Fix #1334: Transformer recipes do not work as shown in EMI in practice

### DIFF
--- a/src/main/resources/data/modern_industrialization/recipe/electric_age/transformer/ev_supra/down_asbl.json
+++ b/src/main/resources/data/modern_industrialization/recipe/electric_age/transformer/ev_supra/down_asbl.json
@@ -1,9 +1,9 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    " OO",
-    "IH ",
-    " OO"
+    "O O",
+    "OHO",
+    " I "
   ],
   "key": {
     "H": {

--- a/src/main/resources/data/modern_industrialization/recipe/electric_age/transformer/ev_supra/up_asbl.json
+++ b/src/main/resources/data/modern_industrialization/recipe/electric_age/transformer/ev_supra/up_asbl.json
@@ -1,9 +1,9 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "II ",
-    " HO",
-    "II "
+    " O ",
+    "IHI",
+    "I I"
   ],
   "key": {
     "H": {

--- a/src/main/resources/data/modern_industrialization/recipe/electric_age/transformer/hv_ev/down_asbl.json
+++ b/src/main/resources/data/modern_industrialization/recipe/electric_age/transformer/hv_ev/down_asbl.json
@@ -1,9 +1,9 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    " OO",
-    "IH ",
-    " OO"
+    "O O",
+    "OHO",
+    " I "
   ],
   "key": {
     "H": {

--- a/src/main/resources/data/modern_industrialization/recipe/electric_age/transformer/hv_ev/up_asbl.json
+++ b/src/main/resources/data/modern_industrialization/recipe/electric_age/transformer/hv_ev/up_asbl.json
@@ -1,9 +1,9 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "II ",
-    " HO",
-    "II "
+    " O ",
+    "IHI",
+    "I I"
   ],
   "key": {
     "H": {

--- a/src/main/resources/data/modern_industrialization/recipe/electric_age/transformer/lv_mv/down_asbl.json
+++ b/src/main/resources/data/modern_industrialization/recipe/electric_age/transformer/lv_mv/down_asbl.json
@@ -1,9 +1,9 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    " OO",
-    "IH ",
-    " OO"
+    "O O",
+    "OHO",
+    " I "
   ],
   "key": {
     "H": {

--- a/src/main/resources/data/modern_industrialization/recipe/electric_age/transformer/lv_mv/up_asbl.json
+++ b/src/main/resources/data/modern_industrialization/recipe/electric_age/transformer/lv_mv/up_asbl.json
@@ -1,9 +1,9 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "II ",
-    " HO",
-    "II "
+    " O ",
+    "IHI",
+    "I I"
   ],
   "key": {
     "H": {

--- a/src/main/resources/data/modern_industrialization/recipe/electric_age/transformer/mv_hv/down_asbl.json
+++ b/src/main/resources/data/modern_industrialization/recipe/electric_age/transformer/mv_hv/down_asbl.json
@@ -1,9 +1,9 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    " OO",
-    "IH ",
-    " OO"
+    "O O",
+    "OHO",
+    " I "
   ],
   "key": {
     "H": {

--- a/src/main/resources/data/modern_industrialization/recipe/electric_age/transformer/mv_hv/up_asbl.json
+++ b/src/main/resources/data/modern_industrialization/recipe/electric_age/transformer/mv_hv/up_asbl.json
@@ -1,9 +1,9 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "II ",
-    " HO",
-    "II "
+    " O ",
+    "IHI",
+    "I I"
   ],
   "key": {
     "H": {


### PR DESCRIPTION
Fixes #1334 

Changes the shape of the transformer recipes to be oriented vertically rather than horizontally. Since Minecraft treats all recipes as symmetrical, those were conflicting and making one or the other uncraftable directly.