### PR TITLE
Fix #1342: Some machine blocks do not have the ability for redstone control modules to be clicked onto it to insert automatically rather than through the GUI

### DIFF
--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/AbstractStorageMachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/AbstractStorageMachineBlockEntity.java
@@ -171,7 +171,11 @@ public abstract class AbstractStorageMachineBlockEntity extends MachineBlockEnti
             }
             return ItemInteractionResult.sidedSuccess(player.level().isClientSide());
         }
-        return super.useItemOn(player, hand, face);
+        var result = super.useItemOn(player, hand, face);
+        if (!result.consumesAction()) {
+            result = redstoneControl.onUse(this, player, hand);
+        }
+        return result;
     }
 
     public static void registerEnergyApi(BlockEntityType<?> bet) {

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/GeneratorMachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/GeneratorMachineBlockEntity.java
@@ -49,7 +49,11 @@ import aztech.modern_industrialization.util.Simulation;
 import aztech.modern_industrialization.util.Tickable;
 import java.util.Collections;
 import java.util.List;
+import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.ItemInteractionResult;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 
 public class GeneratorMachineBlockEntity extends MachineBlockEntity implements Tickable, EnergyComponentHolder, CableTierHolder {
@@ -206,6 +210,15 @@ public class GeneratorMachineBlockEntity extends MachineBlockEntity implements T
                 }
             });
         });
+    }
+
+    @Override
+    protected ItemInteractionResult useItemOn(Player player, InteractionHand hand, Direction face) {
+        var result = super.useItemOn(player, hand, face);
+        if (!result.consumesAction()) {
+            result = redstoneControl.onUse(this, player, hand);
+        }
+        return result;
     }
 
     @Override

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/ReplicatorMachineBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/ReplicatorMachineBlockEntity.java
@@ -44,11 +44,15 @@ import aztech.modern_industrialization.thirdparty.fabrictransfer.api.transaction
 import aztech.modern_industrialization.util.Tickable;
 import java.util.Collections;
 import java.util.List;
+import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.ItemInteractionResult;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.material.Fluid;
@@ -196,5 +200,14 @@ public class ReplicatorMachineBlockEntity extends MachineBlockEntity implements 
 
             setChanged();
         }
+    }
+
+    @Override
+    protected ItemInteractionResult useItemOn(Player player, InteractionHand hand, Direction face) {
+        var result = super.useItemOn(player, hand, face);
+        if (!result.consumesAction()) {
+            result = redstoneControl.onUse(this, player, hand);
+        }
+        return result;
     }
 }

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/NuclearReactorMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/NuclearReactorMultiblockBlockEntity.java
@@ -46,6 +46,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import net.minecraft.core.Direction;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.ItemInteractionResult;
+import net.minecraft.world.entity.player.Player;
 
 public class NuclearReactorMultiblockBlockEntity extends MultiblockMachineBlockEntity implements Tickable {
     private static final ShapeTemplate[] shapeTemplates;
@@ -123,6 +126,15 @@ public class NuclearReactorMultiblockBlockEntity extends MultiblockMachineBlockE
                 efficiencyHistory.clear();
             }
         }
+    }
+
+    @Override
+    protected ItemInteractionResult useItemOn(Player player, InteractionHand hand, Direction face) {
+        var result = super.useItemOn(player, hand, face);
+        if (!result.consumesAction()) {
+            result = redstoneControl.onUse(this, player, hand);
+        }
+        return result;
     }
 
     @Override

--- a/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/SteamBoilerMultiblockBlockEntity.java
+++ b/src/main/java/aztech/modern_industrialization/machines/blockentities/multiblocks/SteamBoilerMultiblockBlockEntity.java
@@ -40,7 +40,11 @@ import aztech.modern_industrialization.machines.multiblocks.ShapeMatcher;
 import aztech.modern_industrialization.machines.multiblocks.ShapeTemplate;
 import aztech.modern_industrialization.util.Tickable;
 import java.util.List;
+import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.ItemInteractionResult;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.material.Fluids;
 
 public class SteamBoilerMultiblockBlockEntity extends MultiblockMachineBlockEntity implements Tickable {
@@ -123,6 +127,15 @@ public class SteamBoilerMultiblockBlockEntity extends MultiblockMachineBlockEnti
             }
             setChanged();
         }
+    }
+
+    @Override
+    protected ItemInteractionResult useItemOn(Player player, InteractionHand hand, Direction face) {
+        var result = super.useItemOn(player, hand, face);
+        if (!result.consumesAction()) {
+            result = redstoneControl.onUse(this, player, hand);
+        }
+        return result;
     }
 
     @Override


### PR DESCRIPTION
Fixes #1342

Applies to:
- Multiblock boilers
- Generators (turbines, diesel)
- Nuclear reactor
- Replicator
- Storage units