### PR TITLE
Fix multiblock rendering crashing when the player does not yet exist

### DIFF
--- a/src/client/java/aztech/modern_industrialization/client/machines/multiblocks/MultiblockMachineBER.java
+++ b/src/client/java/aztech/modern_industrialization/client/machines/multiblocks/MultiblockMachineBER.java
@@ -101,12 +101,15 @@ public class MultiblockMachineBER extends MachineBlockEntityRenderer<MultiblockM
 
     private static boolean isHoldingWrench() {
         Player player = Minecraft.getInstance().player;
-        return player.getMainHandItem().is(MITags.WRENCHES) || player.getOffhandItem().is(MITags.WRENCHES);
+        return player != null && (player.getMainHandItem().is(MITags.WRENCHES) || player.getOffhandItem().is(MITags.WRENCHES));
     }
 
     @Nullable
     private static HatchType getHeldHatchType() {
         Player player = Minecraft.getInstance().player;
+        if (player == null) {
+            return null;
+        }
         HatchType mainHand = getHatchType(player.getMainHandItem());
         HatchType offHand = getHatchType(player.getOffhandItem());
         return mainHand == null ? offHand : mainHand;


### PR DESCRIPTION
Can only happen when using the `guideme.showOnStartup` system property and looking at a scene with a multiblock in it.